### PR TITLE
Fix lock (queue next pattern) functionality

### DIFF
--- a/arm9/source/main.cpp
+++ b/arm9/source/main.cpp
@@ -1273,7 +1273,7 @@ void updateGuiToNewPattern(u8 newpattern)
 // Callback called from song when the pot element changes during playback
 void handlePotPosChangeFromSong(u16 newpotpos)
 {
-	if (state->queued_potpos >= 0 && !tbpotloop->getState()) {
+	if (state->queued_potpos >= 0 && tbpotloop->getState()) {
 		state->potpos = state->queued_potpos;
 		state->setPlaybackRow(0);
 


### PR DESCRIPTION
This makes the song loop/lock feature work as intended - when the end of the current pattern is reached, playback will jump to the queued pattern.

Fixes #97