### PR TITLE
Fix 'B' notes showing as 'H' in the pattern editor

### DIFF
--- a/arm9/source/tobkit/patternview.h
+++ b/arm9/source/tobkit/patternview.h
@@ -73,7 +73,7 @@
 #define SHARP	20
 #define SPACE	21
 
-const u8 notes_chars[] =   {12, 12, 13, 13, 14, 15, 15, 16, 16, 10, 10, 17};
+const u8 notes_chars[] =   {12, 12, 13, 13, 14, 15, 15, 16, 16, 10, 10, 11};
 const u8 notes_signs[] =   {0 , 1 , 0 , 1 , 0 , 0 , 1 , 0 , 1 , 0 , 1 ,  0};
 
 // TODO: Define width/height of cells


### PR DESCRIPTION
This PR fixes a mistake in the pattern display whereby a note such as 'B-4' would render as 'H-4'.

Before:
![image](https://github.com/asiekierka/nitrotracker/assets/569607/38b7ae1d-f2f9-423c-8c5a-3a5cbed6774c)

After:
![image](https://github.com/asiekierka/nitrotracker/assets/569607/c233bb7d-a873-4938-964b-2a522e18d5fa)
