### PR TITLE
Fix sample panning slider

### DIFF
--- a/arm9/source/main.cpp
+++ b/arm9/source/main.cpp
@@ -2340,6 +2340,7 @@ void handleSamplePanningChange(s32 newpanning)
 	u8 pan = newpanning * 2;
 
 	smp->setPanning(pan);
+	smp->setBasePanning();
 	DC_FlushAll();
 }
 


### PR DESCRIPTION
This PR fixes the sample panning control which had no effect, because it never updated the `base_panning`.

This should go hand in hand with this ntxm PR: https://github.com/asiekierka/libntxm/pull/3 to fix various panning related bugs including https://github.com/asiekierka/nitrotracker/issues/105