### PR TITLE
Scroll instruments list with Y+D-pad

### DIFF
--- a/arm9/source/main.cpp
+++ b/arm9/source/main.cpp
@@ -3460,12 +3460,19 @@ void move_to_top(void)
 	redraw_main_requested = true;
 }
 
+void move_inst_to_top(void)
+{
+	handleInstChange(0);
+	lbinstruments->highlight(0);
+	lbinstruments->select(0);
+}
+
 // Update the state for certain keypresses
 void handleButtons(u16 buttons, u16 buttonsheld)
 {
 	u16 ptnlen = song->getPatternLength(song->getPotEntry(state->potpos));
 
-	if(!(buttonsheld & mykey_R))
+	if(!(buttonsheld & mykey_R) && !(buttonsheld & mykey_Y))
 	{
 		if(buttons & mykey_UP)
 		{
@@ -3501,7 +3508,29 @@ void handleButtons(u16 buttons, u16 buttonsheld)
 			state->setCursorRow(newrow);
 
 			pv->updateSelection();
+
 			redraw_main_requested = true;
+		}
+		
+	}
+
+	if(!(buttonsheld & mykey_R) && (buttonsheld & mykey_Y))
+	{
+		int move_by = (buttonsheld & mykey_B) ? 4 : 1;
+		u16 cur_i = lbinstruments->getidx();
+		u16 new_i = cur_i;
+		if(buttons & mykey_DOWN) {
+			new_i = cur_i + move_by >= 0x7f ? 0x7f : cur_i + move_by;
+			lbinstruments->highlight(new_i);
+			lbinstruments->select(new_i);
+			handleInstChange(new_i);
+		}
+
+		if(buttons & mykey_UP) {
+			new_i = cur_i - move_by <= 0 ? 0 : cur_i - move_by;
+			lbinstruments->highlight(new_i);
+			lbinstruments->select(new_i);
+			handleInstChange(new_i);
 		}
 	}
 
@@ -3585,10 +3614,13 @@ void VblankHandler(void)
 
 	if(keysheld & mykey_R)
 	{
-		if(keysheld & mykey_DOWN)
-			move_to_bottom();
-		else if(keysheld & mykey_UP)
-			move_to_top();
+		if(!(keysheld & mykey_Y)) {
+			if(keysheld & mykey_DOWN)
+				move_to_bottom();
+			else if(keysheld & mykey_UP)
+				move_to_top();
+		} else if (keysheld & mykey_UP)
+			move_inst_to_top();
 	}
 
 	if(keysdown & ~KEY_TOUCH)

--- a/arm9/source/main.cpp
+++ b/arm9/source/main.cpp
@@ -3521,14 +3521,12 @@ void handleButtons(u16 buttons, u16 buttonsheld)
 		u16 new_i = cur_i;
 		if(buttons & mykey_DOWN) {
 			new_i = cur_i + move_by >= 0x7f ? 0x7f : cur_i + move_by;
-			lbinstruments->highlight(new_i);
 			lbinstruments->select(new_i);
 			handleInstChange(new_i);
 		}
 
 		if(buttons & mykey_UP) {
 			new_i = cur_i - move_by <= 0 ? 0 : cur_i - move_by;
-			lbinstruments->highlight(new_i);
 			lbinstruments->select(new_i);
 			handleInstChange(new_i);
 		}


### PR DESCRIPTION
Inspired by #118 (although it doesn't do anything nearly as drastic as reworking tobkit to support focusing).

The Y button is currently unused, and it's common for trackers to include shortcuts to easily scroll up and down the instrument list, without use of the computer mouse.

Y+Up and Y+Down move up and down, respectively (no wraparound).

Holding B during this operation moves in units of four rows instead of one, in the same manner as the pattern editor.

Y+R+Up jumps to the top of the instrument list. Y+R+Down, however, does not jump to the bottom, as it is ambiguous as to whether it should jump to the maximum scrollable instrument slot (always 0x7f, or 80), or the last populated instrument.

(redid previous pr as I messed something up and it got cluttered)