### PR TITLE
Trim oversized pastes instead of blocking

### DIFF
--- a/arm9/source/cell_array.cpp
+++ b/arm9/source/cell_array.cpp
@@ -78,6 +78,23 @@ void CellArray::paste(Cell **ptn, int width, int height, int x1, int y1)
     }
 }
 
+void CellArray::paste(CellArray* cellarr, int x1, int y1)
+{
+    int x2 = std::min(cellarr->width(), x1 + array_width);
+    int y2 = std::min(cellarr->height(), y1 + array_height);
+    
+    Cell *src = array;
+
+    for (int x = x1; x < x2; x++, src += array_height)
+    {
+        for (int y = y1; y < y2; y++) 
+        {
+            Cell *dst = cellarr->ptr(x, y);
+            memcpy(dst, src + y, sizeof(Cell));
+        }
+    }
+}
+
 void CellArray::for_each(std::function<void(Cell*)> cell_fn)
 {
     Cell *dst = array;

--- a/arm9/source/cell_array.h
+++ b/arm9/source/cell_array.h
@@ -22,6 +22,7 @@ class CellArray {
 
         void copy(Cell **ptn, int x1, int y1);
         void paste(Cell **ptn, int width, int height, int x1, int y1);
+        void paste(CellArray *cellarr, int x1, int y1);
 
         CellArray *clone();
 		

--- a/arm9/source/main.cpp
+++ b/arm9/source/main.cpp
@@ -2294,31 +2294,22 @@ void handleCopy(void)
 
 void handlePaste(void)
 {
-	int ptn_n_rows = song->getPatternLength(state->potpos);
-	int n_channels = song->getChannels();
-	u8 rows_over = std::max((s16)(clipboard->height() + state->getCursorRow()) - ptn_n_rows, 0);
-	u8 cols_over = std::max((s16)(clipboard->width() + state->channel) - n_channels, 0);
-	
-	CellArray *new_i;
-	u8 new_height = clipboard->height() - rows_over;
-	u8 new_width = clipboard->width() - cols_over;
 	if(clipboard != NULL) {
+		int ptn_n_rows = song->getPatternLength(state->potpos);
+		int n_channels = song->getChannels();
+		u8 rows_over = std::max((s16)(clipboard->height() + state->getCursorRow()) - ptn_n_rows, 0);
+		u8 cols_over = std::max((s16)(clipboard->width() + state->channel) - n_channels, 0);
+		
+		CellArray *new_i;
+		u8 new_height = clipboard->height() - rows_over;
+		u8 new_width = clipboard->width() - cols_over;
+
 		if (rows_over > 0 || cols_over > 0) 
 			new_i = new CellArray(new_width, new_height);
 		
 		if ((rows_over > 0 || cols_over > 0) && new_i != NULL) {
 			my_dprintf("paste is oversized by %u rows and %u cols, trimming\n", rows_over, cols_over);
-
-			int x = 0, y = 0;
-			clipboard->for_each([new_i, new_height, new_width, &x, &y](Cell *c){  // uhhhh
-				if (y < new_height && x < new_width)
-					new_i->ptr(0, 0)[x * new_height + y] = *c;
-
-				if (++y == clipboard->height()) {
-					y = 0;
-					x++;
-				}
-			});
+			clipboard->paste(new_i, 0, 0);
 
 			action_buffer->add(song, new MultipleCellSetAction(state, state->channel, state->getCursorRow(), new_i, true));
 			delete new_i;

--- a/arm9/source/main.cpp
+++ b/arm9/source/main.cpp
@@ -2294,8 +2294,34 @@ void handleCopy(void)
 
 void handlePaste(void)
 {
+	int ptn_n_rows = song->getPatternLength(state->potpos);
+	int n_channels = song->getChannels();
+	u8 rows_over = std::max((s16)(clipboard->height() + state->getCursorRow()) - ptn_n_rows, 0);
+	u8 cols_over = std::max((s16)(clipboard->width() + state->channel) - n_channels, 0);
+	
 	if(clipboard != NULL) {
-		action_buffer->add(song, new MultipleCellSetAction(state, state->channel, state->getCursorRow(), clipboard, true));
+		if (rows_over > 0 || cols_over > 0) {
+			u8 new_height = clipboard->height() - rows_over;
+			u8 new_width = clipboard->width() - cols_over;
+			CellArray *new_i = new CellArray(new_width, new_height);
+
+			my_dprintf("paste is oversized by %u rows and %u cols, trimming\n", rows_over, cols_over);
+
+			int x = 0, y = 0;
+			clipboard->for_each([new_i, new_height, new_width, &x, &y](Cell *c){  // uhhhh
+				if (y < new_height && x < new_width)
+					new_i->ptr(0, 0)[x * new_height + y] = *c;
+
+				if (++y == clipboard->height()) {
+					y = 0;
+					x++;
+				}
+			});
+
+			action_buffer->add(song, new MultipleCellSetAction(state, state->channel, state->getCursorRow(), new_i, true));
+			delete new_i;
+		} else 
+			action_buffer->add(song, new MultipleCellSetAction(state, state->channel, state->getCursorRow(), clipboard, true));
 	}
 
 	redraw_main_requested = true;

--- a/arm9/source/main.cpp
+++ b/arm9/source/main.cpp
@@ -2299,12 +2299,14 @@ void handlePaste(void)
 	u8 rows_over = std::max((s16)(clipboard->height() + state->getCursorRow()) - ptn_n_rows, 0);
 	u8 cols_over = std::max((s16)(clipboard->width() + state->channel) - n_channels, 0);
 	
+	CellArray *new_i;
+	u8 new_height = clipboard->height() - rows_over;
+	u8 new_width = clipboard->width() - cols_over;
 	if(clipboard != NULL) {
-		if (rows_over > 0 || cols_over > 0) {
-			u8 new_height = clipboard->height() - rows_over;
-			u8 new_width = clipboard->width() - cols_over;
-			CellArray *new_i = new CellArray(new_width, new_height);
-
+		if (rows_over > 0 || cols_over > 0) 
+			new_i = new CellArray(new_width, new_height);
+		
+		if ((rows_over > 0 || cols_over > 0) && new_i != NULL) {
 			my_dprintf("paste is oversized by %u rows and %u cols, trimming\n", rows_over, cols_over);
 
 			int x = 0, y = 0;
@@ -2323,7 +2325,6 @@ void handlePaste(void)
 		} else 
 			action_buffer->add(song, new MultipleCellSetAction(state, state->channel, state->getCursorRow(), clipboard, true));
 	}
-
 	redraw_main_requested = true;
 }
 


### PR DESCRIPTION
this might not be ideal given how much it expands `handlePaste`, however I chose to make the changes in this way to limit the scope of the pr without having to go changing a bunch of access specifiers 

Fixes #140