### PR TITLE
Fix PatternView column line height

### DIFF
--- a/arm9/source/tobkit/patternview.cpp
+++ b/arm9/source/tobkit/patternview.cpp
@@ -309,7 +309,7 @@ void PatternView::draw(void)
 	
 	// V-Lines
 	for(u16 i=0;i<=getNumVisibleChannels();++i) {
-		drawVLine(PV_BORDER_WIDTH-1+i*getCellWidth(), 0, width-PV_BORDER_WIDTH, linescol);
+		drawVLine(PV_BORDER_WIDTH-1+i*getCellWidth(), 0, height, linescol);
 	}
 	
 	// Cursor bar (highlight)


### PR DESCRIPTION
probably won't be an actually material issue but when I was experimenting with the patternview width I noticed the column lines were being drawn beyond the framebuffer if pv width is increased beyond around 250