### PR TITLE
Display instrument value properly

### DIFF
--- a/arm9/source/tobkit/patternview.h
+++ b/arm9/source/tobkit/patternview.h
@@ -227,36 +227,35 @@ class PatternView: public Widget {
 					drawChar(MINUS, realx+1*PV_CHAR_WIDTH, realy, notecol);
 				}
 				drawChar(cell->note/12, realx+2*PV_CHAR_WIDTH, realy, notecol);
-				
-				// Instrument
-				drawHexByte(cell->instrument+1, realx+3*PV_CHAR_WIDTH+1, realy, instrcol); // Adding one because FT2 indices start with 1
 			}
+
+			// Instrument
+			if(cell->instrument != NO_INSTRUMENT)
+				drawHexByte(cell->instrument+1, realx+3*PV_CHAR_WIDTH+1, realy, instrcol); // Adding one because FT2 indices start with 1
 			
 			// Volume
 			if(cell->volume != NO_VOLUME)
 				drawHexByte(cell->volume, realx+5*PV_CHAR_WIDTH+2, realy, volumecol);
 			
-			if (effects_visible)
-			{
-        // Effect and effect parameter
-        if (cell->effect != 0xff)
-          drawHexByte(cell->effect, realx+7*PV_CHAR_WIDTH+2, realy, effectcol);
+			if(effects_visible) {
+				// Effect and effect parameter
+				if (cell->effect != 0xff)
+					drawHexByte(cell->effect, realx+7*PV_CHAR_WIDTH+2, realy, effectcol);
 
-        if (cell->effect_param != 0x00)
-          drawHexByte(cell->effect_param, realx+9*PV_CHAR_WIDTH+2, realy, effectparamcol);
-      }
-    }
+				if (cell->effect_param != 0x00)
+					drawHexByte(cell->effect_param, realx+9*PV_CHAR_WIDTH+2, realy, effectparamcol);
+			}
+		}
 		
 		void updateFromState(void);
 	
 		inline u8 getCellWidth(void)
 		{
-		  if (effects_visible)
-		  {
-		    cell_width = 50;
-		  } else {
-		    cell_width = 31;
-		  }
+			if (effects_visible) {
+				cell_width = 50;
+			} else {
+				cell_width = 31;
+			}
 			return cell_width;
 		}
 


### PR DESCRIPTION
- Instrument value is shown even if there is no note in a row
- In rows with a note but no instrument, the instrument is shown as blank instead of 0

these aren't normally possible to make in NT, but can happen in XMs from other trackers
also cleaned up some whitespace, the mixed tabs and spaces bothered me