### PR TITLE
Fix togglebutton corruption

### DIFF
--- a/tobkit/source/togglebutton.cpp
+++ b/tobkit/source/togglebutton.cpp
@@ -138,6 +138,6 @@ void ToggleButton::draw(void)
 	}
 
 	if (caption != NULL)
-		drawString(caption, MAX(2, ((width-getStringWidth(caption))/2) ), col, height/2-5);
+		drawString(caption, MAX(2, ((width-getStringWidth(caption))/2) ), height/2-5, col);
 }
 


### PR DESCRIPTION
Some args being the wrong way round caused the lock/loop buttons to display incorrectly and draw junk on the screen