### PR TITLE
User-configurable themes

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,4 +33,5 @@ jobs:
             nitroustracker*.nds
             CHANGELOG.TXT
             licenses/
+            themes/
             README.TXT

--- a/arm9/source/main.cpp
+++ b/arm9/source/main.cpp
@@ -3353,7 +3353,7 @@ void setupGUI(bool dldi_enabled)
 		buttonunmuteall = new Button(RIGHT_SIDE_BUTTON_X, 22, RIGHT_SIDE_BUTTON_WIDTH, 12, &main_vram_back);
 		buttonunmuteall->setCaption("-m/s");
 
-		labelnotevol = new Label(RIGHT_SIDE_BUTTON_X + 5, 34, RIGHT_SIDE_BUTTON_WIDTH - 7, 9, &main_vram_back, false, true);
+		labelnotevol = new Label(RIGHT_SIDE_BUTTON_X + 5, 34, RIGHT_SIDE_BUTTON_WIDTH - 7, 9, &main_vram_back, false, true, true);
 		labelnotevol->setCaption("vol");
 
 		nsnotevolume	 = new NumberSlider(RIGHT_SIDE_BUTTON_X, 45, RIGHT_SIDE_BUTTON_WIDTH, 17, &main_vram_back, 127, 0, 127, true, true);

--- a/arm9/source/main.cpp
+++ b/arm9/source/main.cpp
@@ -273,7 +273,7 @@ void dumpSample(void);
 
 void clearMainScreen(void)
 {
-	u16 col = settings->getTheme()->col_dark_bg;
+	u16 col = settings->getTheme()->col_bg;
 	u32 colcol = col | col << 16;
 	dmaFillWords(colcol, main_vram_front, 256 * 192 * 2);
 	dmaFillWords(colcol, main_vram_back, 256 * 192 * 2);
@@ -281,7 +281,7 @@ void clearMainScreen(void)
 
 void clearSubScreen(void)
 {
-	u16 col = settings->getTheme()->col_dark_bg;
+	u16 col = settings->getTheme()->col_bg;
 	u32 colcol = col | col << 16;
 	// Fill the bg with the bg color except for the place where the keyboard is
 	dmaFillWords(colcol, sub_vram, 256 * 153 * 2);
@@ -2792,7 +2792,7 @@ void sampleDrawToggle(bool on)
 void setupGUI(bool dldi_enabled)
 {
 	gui = new GUI();
-	gui->setTheme(settings->getTheme(), settings->getTheme()->col_dark_bg);
+	gui->setTheme(settings->getTheme(), settings->getTheme()->col_bg);
 
 	kb = new Piano(0, 152, 224, 40, (uint16*)CHAR_BASE_BLOCK_SUB(0), (uint16*)SCREEN_BASE_BLOCK_SUB(1/*8*/), &sub_vram);
 	kb->registerNoteCallback(handleNoteStroke);
@@ -2803,7 +2803,7 @@ void setupGUI(bool dldi_enabled)
 	pixmaplogo->registerPushCallback(showAboutBox);
 
 	tabbox = new TabBox(1, 1, 139, 151, &sub_vram, TABBOX_ORIENTATION_TOP, 16);
-	tabbox->setTheme(settings->getTheme(), settings->getTheme()->col_dark_bg);
+	tabbox->setTheme(settings->getTheme(), settings->getTheme()->col_bg);
 	tabbox->addTab(icon_song_raw, 0);
 	if (dldi_enabled)
 		tabbox->addTab(icon_disk_raw, 1);
@@ -3000,7 +3000,7 @@ void setupGUI(bool dldi_enabled)
 	sampledisplay->setActive();
 
 	sampletabbox = new TabBox(3, 94, 132, 55, &sub_vram, TABBOX_ORIENTATION_LEFT, 11);
-	sampletabbox->setTheme(settings->getTheme(), settings->getTheme()->col_dark_bg);
+	sampletabbox->setTheme(settings->getTheme(), settings->getTheme()->col_smp_bg);
 	sampletabbox->addTab(sampleedit_wave_icon_raw, 0);
 	sampletabbox->addTab(sampleedit_draw_small_raw, 1);
 	sampletabbox->addTab(sampleedit_control_icon_raw, 2);

--- a/arm9/source/main.cpp
+++ b/arm9/source/main.cpp
@@ -3860,12 +3860,20 @@ int main(int argc, char **argv) {
 	REG_BLDCNT_SUB = BLEND_FADE_BLACK | BLEND_SRC_BG2 | BLEND_SRC_BG0;
 	REG_BLDCNT = BLEND_FADE_BLACK | BLEND_SRC_BG2 | BLEND_SRC_BG0;
 #endif
-
+	#ifdef USE_FAT
+	bool fat_success = fatInitDefault();
+#else
+    bool fat_success = false;
+#endif
 	// Setup text
 	consoleInit(NULL, 0, BgType_Text4bpp, BgSize_T_256x256, 4, 0, true, true);
 	bgSetPriority(0, text_priority);
 
 	bgUpdate();
+
+	settings = new Settings(launch_path, fat_success);
+
+
 
 	// Set draw loactions for the ERBs
 	main_vram_front = (uint16*)BG_BMP_RAM(2);
@@ -3875,11 +3883,7 @@ int main(int argc, char **argv) {
 	// Clear tile mem
 	dmaFillWords(0, BG_BMP_RAM_SUB(0), 32*1024);
 
-#ifdef USE_FAT
-	bool fat_success = fatInitDefault();
-#else
-    bool fat_success = false;
-#endif
+
 
 	// parse argv[0], if present
 	if (argc >= 1 && argv != NULL && argv[0] != NULL) {
@@ -3898,9 +3902,7 @@ int main(int argc, char **argv) {
 	}
 
 	state = new State();
-
-	settings = new Settings(launch_path, fat_success);
-
+	
 	clearMainScreen();
 	clearSubScreen();
 

--- a/arm9/source/settings.cpp
+++ b/arm9/source/settings.cpp
@@ -23,10 +23,8 @@
  */
 
 #include "settings.h"
-
 #include <stdio.h>
 #include <string.h>
-
 #include "tools.h"
 
 #define SETTINGS_DEFAULT_DATA_DIR "/data/NitroTracker"
@@ -38,11 +36,12 @@ Settings::Settings(char *launch_path, bool use_fat)
 : handedness(RIGHT_HANDED),
 sample_preview(true),
 stereo_output(true),
-theme(new tobkit::Theme()),
 fat(use_fat), changed(false)
 {
 	songpath[SETTINGS_FILENAME_LEN] = '\0';
 	samplepath[SETTINGS_FILENAME_LEN] = '\0';
+	themename[THEME_NAME_LEN] = '\0';
+	themepath[SETTINGS_FILENAME_LEN] = '\0';
 
 	// might never have snprintf called
 	configpath[0] = '\0';
@@ -50,6 +49,8 @@ fat(use_fat), changed(false)
 
 	snprintf(songpath, SETTINGS_FILENAME_LEN, "%s/", launch_path != NULL ? launch_path : "");
 	snprintf(samplepath, SETTINGS_FILENAME_LEN, "%s/", launch_path != NULL ? launch_path : "");
+	snprintf(themename, SETTINGS_FILENAME_LEN, "Default.nttheme");
+	
 
 	if(fat == true)
 	{
@@ -57,6 +58,7 @@ fat(use_fat), changed(false)
 		{
 			dirCreate("/data");
 			dirCreate("/data/NitroTracker");
+			dirCreate("/data/NitroTracker/Themes");
 		}
 
 		snprintf(configpath, SETTINGS_FILENAME_LEN, "%s/%s",
@@ -101,9 +103,16 @@ fat(use_fat), changed(false)
 			if (!lines_per_beat || lines_per_beat > 64)
 				lines_per_beat = 8;
 
+			getConfigValue(confstr, "Theme", themename, SETTINGS_FILENAME_LEN, NULL);
+			
 			free(confstr);
 		}
 	}
+
+	snprintf(themepath, SETTINGS_FILENAME_LEN, "%s/Themes/%s",
+				launch_path != NULL ? launch_path : SETTINGS_DEFAULT_DATA_DIR,
+				themename); // will default to 'Default.nttheme' if no fat
+	theme = new tobkit::Theme(themepath, fat);
 }
 
 Handedness Settings::getHandedness(void)
@@ -180,6 +189,7 @@ char *Settings::getSongPath(void)
     return songpath;
 }
 
+
 void Settings::setSongPath(const char* songpath_)
 {
 	strncpy(songpath, songpath_, SETTINGS_FILENAME_LEN);
@@ -229,8 +239,8 @@ bool Settings::write(void)
 	boolToString(sample_preview, prevstring);
 	boolToString(stereo_output, stereostring);
 	boolToString(freq_47khz, freqstring);
-	fprintf(conf, "Samplepath = %s\nSongpath = %s\nHandedness = %s\nSample Preview = %s\nStereo Output = %s\n47kHz Output = %s\nLines Per Beat = %d\n",
-			samplepath, songpath, hstring, prevstring, stereostring, freqstring, lines_per_beat);
+	fprintf(conf, "Samplepath = %s\nSongpath = %s\nHandedness = %s\nSample Preview = %s\nStereo Output = %s\n47kHz Output = %s\nLines Per Beat = %d\nTheme = %s\n",
+			samplepath, songpath, hstring, prevstring, stereostring, freqstring, lines_per_beat, themename);
 	fclose(conf);
 	return true;
 }

--- a/arm9/source/settings.h
+++ b/arm9/source/settings.h
@@ -32,6 +32,7 @@
 #include <stdlib.h>
 
 #define SETTINGS_FILENAME_LEN 255
+#define THEME_NAME_LEN 63
 
 enum Handedness {LEFT_HANDED, RIGHT_HANDED};
 
@@ -86,6 +87,8 @@ class Settings {
 		char configpath[SETTINGS_FILENAME_LEN + 1];
 		char songpath[SETTINGS_FILENAME_LEN + 1];
 		char samplepath[SETTINGS_FILENAME_LEN + 1];
+		char themename[THEME_NAME_LEN + 1];
+		char themepath[SETTINGS_FILENAME_LEN + 1];
         bool fat, changed;
 };
 

--- a/arm9/source/tobkit/envelope_editor.cpp
+++ b/arm9/source/tobkit/envelope_editor.cpp
@@ -458,7 +458,7 @@ void EnvelopeEditor::draw(void)
 	//
 	// Border and background
 	//
-	drawFullBox(1, 1, width - 2, height - 2, theme->col_dark_bg);
+	drawFullBox(1, 1, width - 2, height - 2, theme->col_env_bg);
 	drawBorder(theme->col_outline);
 
 	if( (draw_mode == true) && (n_points == 0) )
@@ -522,7 +522,7 @@ void EnvelopeEditor::draw(void)
 			    drawBresLine(last_point_x, last_point_y, last_point_x, MAX_Y, theme->col_env_sustain);
 			  }
 			}
-			drawBresLine(line_x1, line_y1, line_x2, line_y2, theme->col_dark_ctrl);
+			drawBresLine(line_x1, line_y1, line_x2, line_y2, theme->col_env_line);
 
 			// Display unclipped points
 			if( (last_point_x >= MIN_X) && (last_point_x <= MAX_X) )
@@ -543,16 +543,16 @@ void EnvelopeEditor::draw(void)
 
 	// Right Button
 	if(buttonstate == SCROLLRIGHT) {
-		drawGradient(theme->col_dark_ctrl, theme->col_light_ctrl, width-9, height-SCROLLBAR_WIDTH+1, 8, 8);
+		drawGradient(theme->col_scrollbar_arr_bg1, theme->col_scrollbar_arr_bg2, width-9, height-SCROLLBAR_WIDTH+1, 8, 8);
 	} else {
-		drawGradient(theme->col_light_ctrl, theme->col_dark_ctrl, width-9, height-SCROLLBAR_WIDTH+1, 8, 8);
+		drawGradient(theme->col_scrollbar_arr_bg2, theme->col_scrollbar_arr_bg1, width-9, height-SCROLLBAR_WIDTH+1, 8, 8);
 	}
 
 	// This draws the right-arrow
 	s8 j, p;
 	for(j=0;j<3;j++) {
 		for(p=-j;p<=j;++p) {
-			*(*vram+SCREEN_WIDTH*(y+height-SCROLLBAR_WIDTH+4+p)+x+width-j-3) = theme->col_icon;
+			*(*vram+SCREEN_WIDTH*(y+height-SCROLLBAR_WIDTH+4+p)+x+width-j-3) = theme->col_icon_bt;
 		}
 	}
 
@@ -560,15 +560,15 @@ void EnvelopeEditor::draw(void)
 
 	// Left Button
 	if(buttonstate==SCROLLLEFT) {
-		drawGradient(theme->col_dark_ctrl, theme->col_light_ctrl, 1, height-9, 8, 8);
+		drawGradient(theme->col_scrollbar_arr_bg1, theme->col_scrollbar_arr_bg2, 1, height-9, 8, 8);
 	} else {
-		drawGradient(theme->col_light_ctrl, theme->col_dark_ctrl, 1, height-9, 8, 8);
+		drawGradient(theme->col_scrollbar_arr_bg2, theme->col_scrollbar_arr_bg1, 1, height-9, 8, 8);
 	}
 
 	// This draws the down-arrow
 	for(j=2;j>=0;j--) {
 		for(p=-j;p<=j;++p) {
-			*(*vram+SCREEN_WIDTH*(y+height-SCROLLBAR_WIDTH+4+p)+x+j+3) = theme->col_icon;
+			*(*vram+SCREEN_WIDTH*(y+height-SCROLLBAR_WIDTH+4+p)+x+j+3) = theme->col_icon_bt;
 		}
 	}
 
@@ -578,13 +578,13 @@ void EnvelopeEditor::draw(void)
 	drawBox(0, height-SCROLLBAR_WIDTH, width, SCROLLBAR_WIDTH, theme->col_outline);
 
 	// Clear Scrollbar
-	drawGradient(theme->col_medium_bg, theme->col_light_bg, SCROLLBUTTON_HEIGHT, height-SCROLLBAR_WIDTH+1, width-2*SCROLLBUTTON_HEIGHT, SCROLLBAR_WIDTH-2);
+	drawGradient(theme->col_scrollbar_bg1, theme->col_scrollbar_bg2, SCROLLBUTTON_HEIGHT, height-SCROLLBAR_WIDTH+1, width-2*SCROLLBUTTON_HEIGHT, SCROLLBAR_WIDTH-2);
 
 	// The scroll thingy
 	if(buttonstate==SCROLLTHINGY) {
-		drawFullBox(SCROLLBUTTON_HEIGHT+scrollthingypos, height-SCROLLBAR_WIDTH+1, scrollthingyheight-2, SCROLLBAR_WIDTH-2, theme->col_light_ctrl);
+		drawFullBox(SCROLLBUTTON_HEIGHT+scrollthingypos, height-SCROLLBAR_WIDTH+1, scrollthingyheight-2, SCROLLBAR_WIDTH-2, theme->col_scrollbar_active);
 	} else {
-		drawFullBox(SCROLLBUTTON_HEIGHT+scrollthingypos, height-SCROLLBAR_WIDTH+1, scrollthingyheight-2, SCROLLBAR_WIDTH-2, theme->col_dark_ctrl);
+		drawFullBox(SCROLLBUTTON_HEIGHT+scrollthingypos, height-SCROLLBAR_WIDTH+1, scrollthingyheight-2, SCROLLBAR_WIDTH-2, theme->col_scrollbar_inactive);
 	}
 
 	drawBox(SCROLLBUTTON_HEIGHT-1+scrollthingypos, height-SCROLLBAR_WIDTH, scrollthingyheight, SCROLLBAR_WIDTH, theme->col_outline);
@@ -600,12 +600,12 @@ void EnvelopeEditor::calcScrollThingy(void)
 
 void EnvelopeEditor::drawPoint(u8 x, u8 y, bool active)
 {
-	drawFullBox(x + POINT_X_OFFSET, y + POINT_Y_OFFSET, POINT_WIDTH, POINT_HEIGHT, theme->col_light_ctrl);
+	drawFullBox(x + POINT_X_OFFSET, y + POINT_Y_OFFSET, POINT_WIDTH, POINT_HEIGHT, theme->col_env_pt);
 
 	if(!active)
-		drawBox(x + POINT_X_OFFSET, y + POINT_Y_OFFSET, POINT_WIDTH, POINT_HEIGHT, theme->col_outline);
+		drawBox(x + POINT_X_OFFSET, y + POINT_Y_OFFSET, POINT_WIDTH, POINT_HEIGHT, theme->col_env_pt_border);
 	else
-		drawBox(x + POINT_X_OFFSET, y + POINT_Y_OFFSET, POINT_WIDTH, POINT_HEIGHT, theme->col_signal);
+		drawBox(x + POINT_X_OFFSET, y + POINT_Y_OFFSET, POINT_WIDTH, POINT_HEIGHT, theme->col_env_pt_border_active);
 }
 
 void EnvelopeEditor::scroll(s32 difference)

--- a/arm9/source/tobkit/numbersliderrelnote.cpp
+++ b/arm9/source/tobkit/numbersliderrelnote.cpp
@@ -163,7 +163,7 @@ void NumberSliderRelNote::draw(void)
 	
 	char notestr[4];
 	snprintf(notestr, sizeof(notestr), "%s%u", nstr, octave);
-	drawString(notestr, 10, 5, theme->col_text_2);
+	drawString(notestr, 10, 5, theme->col_text_value);
 	
 	// Border
 	drawBorder(theme->col_outline);

--- a/arm9/source/tobkit/numbersliderrelnote.cpp
+++ b/arm9/source/tobkit/numbersliderrelnote.cpp
@@ -122,17 +122,17 @@ void NumberSliderRelNote::draw(void)
 	s8 i,j;
 	for(j=0;j<3;j++) {
 		for(i=-j;i<=j;++i) {
-			*(*vram+SCREEN_WIDTH*(y+j+3)+x+4+i) = theme->col_icon;
+			*(*vram+SCREEN_WIDTH*(y+j+3)+x+4+i) = theme->col_text_bt;
 		}
 	}
 	
 	// This draws the connection
-	drawVLine(4, 6, 5, theme->col_outline);
+	drawVLine(4, 6, 5, theme->col_text_bt);
 	
 	// This draws the down-arrow
 	for(j=2;j>=0;j--) {
 		for(i=-j;i<=j;++i) {
-			*(*vram+SCREEN_WIDTH*(y-j+13)+x+4+i) = theme->col_icon;
+			*(*vram+SCREEN_WIDTH*(y-j+13)+x+4+i) = theme->col_text_bt;
 		}
 	}
 	
@@ -163,7 +163,7 @@ void NumberSliderRelNote::draw(void)
 	
 	char notestr[4];
 	snprintf(notestr, sizeof(notestr), "%s%u", nstr, octave);
-	drawString(notestr, 10, 5, theme->col_text);
+	drawString(notestr, 10, 5, theme->col_text_2);
 	
 	// Border
 	drawBorder(theme->col_outline);

--- a/arm9/source/tobkit/patternview.cpp
+++ b/arm9/source/tobkit/patternview.cpp
@@ -321,7 +321,7 @@ void PatternView::draw(void)
 	s16 ip;
 	for(ip=state->getCursorRow()-getCursorBarPos();ip<=state->getCursorRow()+getCursorBarPos()+1;++ip) {
 		if((ip>=0)&&(ip<ptnlen)) {
-			drawHexByte(ip, 1, 2+(ip+getCursorBarPos()-state->getCursorRow())*PV_CHAR_HEIGHT, theme->col_pv_left_numbers);
+			drawHexByte(ip, 1, 2+(ip+getCursorBarPos()-state->getCursorRow())*PV_CHAR_HEIGHT, ip % lines_per_beat == 0 ? theme->col_pv_left_numbers_highlight : theme->col_pv_left_numbers);
 		}
 	}
 	

--- a/arm9/source/tobkit/patternview.cpp
+++ b/arm9/source/tobkit/patternview.cpp
@@ -309,11 +309,11 @@ void PatternView::draw(void)
 	// Playback box
 	int playback_box_y = PV_CURSORBAR_Y + (state->getPlaybackRow()-state->getCursorRow())*PV_CELL_HEIGHT;
 	if (playback_box_y >= 0 && playback_box_y < 192) {
-		drawBox(0, playback_box_y, getEffectiveWidth(), PV_CELL_HEIGHT+1, theme->col_outline);
+		drawBox(0, playback_box_y, getEffectiveWidth(), PV_CELL_HEIGHT+1, theme->col_pv_pb);
 	}
 
 	// Cursor
-	drawBox(PV_BORDER_WIDTH-1+(state->channel-hscrollpos)*getCellWidth(), PV_CURSORBAR_Y, getCellWidth()+1, PV_CELL_HEIGHT+1, theme->col_outline);
+	drawBox(PV_BORDER_WIDTH-1+(state->channel-hscrollpos)*getCellWidth(), PV_CURSORBAR_Y, getCellWidth()+1, PV_CELL_HEIGHT+1, theme->col_pv_pb_cell);
 	drawGradient(theme->col_pv_cb_col1_highlight, theme->col_pv_cb_col2_highlight, PV_BORDER_WIDTH+(state->channel-hscrollpos)*getCellWidth(),
 				 PV_CURSORBAR_Y+1, getCellWidth()-1, PV_CELL_HEIGHT-1);
 	
@@ -350,7 +350,7 @@ void PatternView::draw(void)
 	{
 		drawFullBox(PV_BORDER_WIDTH+i*getCellWidth()+1, 1, getCellWidth()-2, 11, theme->col_pv_bg);
 		snprintf(numberstr, sizeof(numberstr), "%-2x", (u8) (hscrollpos+i));
-		drawString(numberstr, PV_BORDER_WIDTH+i*getCellWidth()+1, 1, theme->col_pv_lines, 255);
+		drawString(numberstr, PV_BORDER_WIDTH+i*getCellWidth()+1, 1, theme->col_pv_chn, 255);
 	}
 	
 	// Mute / Solo buttons
@@ -364,31 +364,31 @@ void PatternView::draw(void)
 		{
 			if(mute_channels[chn] == true)
 			{
-				mute_col1 = theme->col_pv_cb_col1_highlight;
-				mute_col2 = theme->col_pv_cb_col2_highlight;
+				mute_col1 = theme->col_pv_mutesolo_col1_highlight;
+				mute_col2 = theme->col_pv_mutesolo_col2_highlight;
 			}
 			else
 			{
-				mute_col1 = theme->col_pv_cb_col1;
-				mute_col2 = theme->col_pv_cb_col2;
+				mute_col1 = theme->col_pv_mutesolo_col1;
+				mute_col2 = theme->col_pv_mutesolo_col2;
 			}
 			drawGradient(mute_col1, mute_col2, MUTE_X(i), MUTE_Y, MUTE_WIDTH, MUTE_HEIGHT);
-			drawString("m", PV_BORDER_WIDTH+i*getCellWidth()+MUTE_REL_X+1, 0, theme->col_text, 255);
+			drawString("m", PV_BORDER_WIDTH+i*getCellWidth()+MUTE_REL_X+1, 0, theme->col_pv_mutesolo_text, 255);
 		}
 		
 		if(solo_channels[chn] == true)
 		{
-			solo_col1 = theme->col_pv_cb_col1_highlight;
-			solo_col2 = theme->col_pv_cb_col2_highlight;
+			solo_col1 = theme->col_pv_mutesolo_col1_highlight;
+			solo_col2 = theme->col_pv_mutesolo_col2_highlight;
 		}
 		else
 		{
-			solo_col1 = theme->col_pv_cb_col1;
-			solo_col2 = theme->col_pv_cb_col2;
+			solo_col1 = theme->col_pv_mutesolo_col1;
+			solo_col2 = theme->col_pv_mutesolo_col2;
 		}
 		
 		drawGradient(solo_col1, solo_col2, SOLO_X(i), SOLO_Y, SOLO_WIDTH, SOLO_HEIGHT);
-		drawString("s", PV_BORDER_WIDTH+i*getCellWidth()+SOLO_REL_X+2, 0, theme->col_text, 255);
+		drawString("s", PV_BORDER_WIDTH+i*getCellWidth()+SOLO_REL_X+2, 0, theme->col_pv_mutesolo_text, 255);
 	}
 }
 

--- a/arm9/source/tobkit/patternview.cpp
+++ b/arm9/source/tobkit/patternview.cpp
@@ -233,7 +233,7 @@ void PatternView::toggleEffectsVisibility(bool on)
 // the whole screen.
 void PatternView::draw(void)
 {
-	u32 colcol = theme->col_bg | theme->col_bg << 16;
+	u32 colcol = theme->col_pv_bg | theme->col_pv_bg << 16;
 	s32 sel_screen_x1 = -1, sel_screen_x2 = -1, sel_screen_y1 = -1, sel_screen_y2 = -1;
 
 	dmaFillWords(colcol, *vram, 192*256*2);
@@ -348,7 +348,7 @@ void PatternView::draw(void)
 	char numberstr[3];
 	for(u16 i=0;i<getNumVisibleChannels();++i)
 	{
-		drawFullBox(PV_BORDER_WIDTH+i*getCellWidth()+1, 1, getCellWidth()-2, 11, theme->col_bg);
+		drawFullBox(PV_BORDER_WIDTH+i*getCellWidth()+1, 1, getCellWidth()-2, 11, theme->col_pv_bg);
 		snprintf(numberstr, sizeof(numberstr), "%-2x", (u8) (hscrollpos+i));
 		drawString(numberstr, PV_BORDER_WIDTH+i*getCellWidth()+1, 1, theme->col_pv_lines, 255);
 	}

--- a/arm9/source/tobkit/sampledisplay.cpp
+++ b/arm9/source/tobkit/sampledisplay.cpp
@@ -391,7 +391,7 @@ void SampleDisplay::draw(void)
 	//
 	// Border and background
 	//
-	drawFullBox(1, 1, width - 2, height - 2, theme->col_dark_bg);
+	drawFullBox(1, 1, width - 2, height - 2, theme->col_smp_bg);
 	
 	if(active==false) {
 		drawBorder(theme->col_outline);
@@ -422,7 +422,7 @@ void SampleDisplay::draw(void)
 
 		selwidth = selright - selleft;
 		if(!dontdraw) {
-			drawFullBox(selleft, 1, selwidth, DRAW_HEIGHT+1, theme->col_sepline);
+			drawFullBox(selleft, 1, selwidth, DRAW_HEIGHT+1, theme->col_smp_bg_sel);
 		}
 	}
 
@@ -432,16 +432,16 @@ void SampleDisplay::draw(void)
 
 	// Right Button
 	if(pen_on_scroll_right) {
-		drawGradient(theme->col_dark_ctrl, theme->col_light_ctrl, width-9, height-SCROLLBAR_WIDTH+1, 8, 8);
+		drawGradient(theme->col_scrollbar_arr_bg1, theme->col_scrollbar_arr_bg2, width-9, height-SCROLLBAR_WIDTH+1, 8, 8);
 	} else {
-		drawGradient(theme->col_light_ctrl, theme->col_dark_ctrl, width-9, height-SCROLLBAR_WIDTH+1, 8, 8);
+		drawGradient(theme->col_scrollbar_arr_bg2, theme->col_scrollbar_arr_bg1, width-9, height-SCROLLBAR_WIDTH+1, 8, 8);
 	}
 
 	// This draws the right-arrow
 	s8 j, p;
 	for(j=0;j<3;j++) {
 		for(p=-j;p<=j;++p) {
-			*(*vram+SCREEN_WIDTH*(y+height-SCROLLBAR_WIDTH+4+p)+x+width-j-3) = theme->col_icon;
+			*(*vram+SCREEN_WIDTH*(y+height-SCROLLBAR_WIDTH+4+p)+x+width-j-3) = theme->col_icon_bt;
 		}
 	}
 
@@ -449,15 +449,15 @@ void SampleDisplay::draw(void)
 
 	// Left Button
 	if(pen_on_scroll_left) {
-		drawGradient(theme->col_dark_ctrl, theme->col_light_ctrl, 1, height-9, 8, 8);
+		drawGradient(theme->col_scrollbar_arr_bg1, theme->col_scrollbar_arr_bg2, 1, height-9, 8, 8);
 	} else {
-		drawGradient(theme->col_light_ctrl, theme->col_dark_ctrl, 1, height-9, 8, 8);
+		drawGradient(theme->col_scrollbar_arr_bg2, theme->col_scrollbar_arr_bg1, 1, height-9, 8, 8);
 	}
 
 	// This draws the down-arrow
 	for(j=2;j>=0;j--) {
 		for(p=-j;p<=j;++p) {
-			*(*vram+SCREEN_WIDTH*(y+height-SCROLLBAR_WIDTH+4+p)+x+j+3) = theme->col_icon;
+			*(*vram+SCREEN_WIDTH*(y+height-SCROLLBAR_WIDTH+4+p)+x+j+3) = theme->col_icon_bt;
 		}
 	}
 
@@ -467,13 +467,13 @@ void SampleDisplay::draw(void)
 	drawBox(0, height-SCROLLBAR_WIDTH, width, SCROLLBAR_WIDTH, theme->col_outline);
 
 	// Clear Scrollbar
-	drawGradient(theme->col_medium_bg, theme->col_light_bg, SCROLLBUTTON_HEIGHT, height-SCROLLBAR_WIDTH+1, width-2*SCROLLBUTTON_HEIGHT, SCROLLBAR_WIDTH-2);
+	drawGradient(theme->col_scrollbar_bg1, theme->col_scrollbar_bg2, SCROLLBUTTON_HEIGHT, height-SCROLLBAR_WIDTH+1, width-2*SCROLLBUTTON_HEIGHT, SCROLLBAR_WIDTH-2);
 
 	// The scroll thingy
 	if(pen_on_scrollthingy) {
-		drawFullBox(SCROLLBUTTON_HEIGHT+scrollthingypos, height-SCROLLBAR_WIDTH+1, scrollthingywidth-2, SCROLLBAR_WIDTH-2, theme->col_light_ctrl);
+		drawFullBox(SCROLLBUTTON_HEIGHT+scrollthingypos, height-SCROLLBAR_WIDTH+1, scrollthingywidth-2, SCROLLBAR_WIDTH-2, theme->col_scrollbar_active);
 	} else {
-		drawFullBox(SCROLLBUTTON_HEIGHT+scrollthingypos, height-SCROLLBAR_WIDTH+1, scrollthingywidth-2, SCROLLBAR_WIDTH-2, theme->col_dark_ctrl);
+		drawFullBox(SCROLLBUTTON_HEIGHT+scrollthingypos, height-SCROLLBAR_WIDTH+1, scrollthingywidth-2, SCROLLBAR_WIDTH-2, theme->col_scrollbar_inactive);
 	}
 
 	drawBox(SCROLLBUTTON_HEIGHT-1+scrollthingypos, height-SCROLLBAR_WIDTH, scrollthingywidth, SCROLLBAR_WIDTH, theme->col_outline);
@@ -485,9 +485,10 @@ void SampleDisplay::draw(void)
 	u16 colortable[DRAW_HEIGHT+2];
 	u16 colortable_selected[DRAW_HEIGHT+2];
 	for(s32 i=0; i<DRAW_HEIGHT+2; i++) {
-		colortable[i] = interpolateColor(theme->col_light_ctrl, theme->col_dark_ctrl, i<<4);
+		// colortable[i] = interpolateColor(theme->col_light_ctrl, theme->col_dark_ctrl, i<<4);
+		colortable[i] = theme->col_smp_waveform;
 		//colortable_selected[i] = ((colortable[i] >> 2) & 0x1CE7) | 0x8000;
-		colortable_selected[i] = 0x8000;
+		colortable_selected[i] = theme->col_smp_waveform_sel;
 	}
 
 	int32 step = divf32(inttof32(smp->getNSamples() >> zoom_level), inttof32(width-2));
@@ -596,30 +597,30 @@ void SampleDisplay::draw(void)
 			// Left Triangle
 			if(loop_start_pos > 1 + LOOP_TRIANGLE_SIZE)
 			{
-				drawHLine(loop_start_pos-2, DRAW_HEIGHT+1-LOOP_TRIANGLE_SIZE, 2, theme->col_icon);
+				drawHLine(loop_start_pos-2, DRAW_HEIGHT+1-LOOP_TRIANGLE_SIZE, 2, theme->col_outline);
 
 				for(u8 i=0; i<LOOP_TRIANGLE_SIZE-2; ++i)
 				{
 					drawHLine(loop_start_pos-i-2, DRAW_HEIGHT+2-LOOP_TRIANGLE_SIZE+i, i+2, theme->col_loop);
-					drawPixel(loop_start_pos-i-3, DRAW_HEIGHT+2-LOOP_TRIANGLE_SIZE+i, theme->col_icon);
+					drawPixel(loop_start_pos-i-3, DRAW_HEIGHT+2-LOOP_TRIANGLE_SIZE+i, theme->col_outline);
 				}
 
 				drawHLine(loop_start_pos-LOOP_TRIANGLE_SIZE+1, DRAW_HEIGHT, LOOP_TRIANGLE_SIZE-1,
 					theme->col_loop);
-				drawPixel(loop_start_pos-LOOP_TRIANGLE_SIZE, DRAW_HEIGHT, theme->col_icon);
+				drawPixel(loop_start_pos-LOOP_TRIANGLE_SIZE, DRAW_HEIGHT, theme->col_outline);
 			}
 
 			// Right Triangle
 			if(loop_start_pos < width - 2 - LOOP_TRIANGLE_SIZE)
 			{
-				drawHLine(loop_start_pos+1, DRAW_HEIGHT+1-LOOP_TRIANGLE_SIZE, 2, theme->col_icon);
+				drawHLine(loop_start_pos+1, DRAW_HEIGHT+1-LOOP_TRIANGLE_SIZE, 2, theme->col_outline);
 				for(u8 i=0; i<LOOP_TRIANGLE_SIZE-2; ++i) {
 					drawHLine(loop_start_pos+1, DRAW_HEIGHT+2-LOOP_TRIANGLE_SIZE+i, 2+i, theme->col_loop);
-					drawPixel(loop_start_pos+3+i, DRAW_HEIGHT+2-LOOP_TRIANGLE_SIZE+i, theme->col_icon);
+					drawPixel(loop_start_pos+3+i, DRAW_HEIGHT+2-LOOP_TRIANGLE_SIZE+i, theme->col_outline);
 				}
 				drawHLine(loop_start_pos+1, DRAW_HEIGHT-LOOP_TRIANGLE_SIZE+LOOP_TRIANGLE_SIZE, LOOP_TRIANGLE_SIZE-1,
 					theme->col_loop);
-				drawPixel(loop_start_pos+LOOP_TRIANGLE_SIZE, DRAW_HEIGHT, theme->col_icon);
+				drawPixel(loop_start_pos+LOOP_TRIANGLE_SIZE, DRAW_HEIGHT, theme->col_outline);
 			}
 		}
 
@@ -635,30 +636,30 @@ void SampleDisplay::draw(void)
 			{
 				drawHLine(loop_end_pos-LOOP_TRIANGLE_SIZE+1, 1, LOOP_TRIANGLE_SIZE-1,
 					theme->col_loop);
-				drawPixel(loop_end_pos-LOOP_TRIANGLE_SIZE, 1, theme->col_icon);
+				drawPixel(loop_end_pos-LOOP_TRIANGLE_SIZE, 1, theme->col_outline);
 
 				for(u8 i=0; i<LOOP_TRIANGLE_SIZE-2; ++i)
 				{
 					drawHLine(loop_end_pos-LOOP_TRIANGLE_SIZE+i+1, 2+i, LOOP_TRIANGLE_SIZE-i-1, theme->col_loop);
-					drawPixel(loop_end_pos-1-LOOP_TRIANGLE_SIZE+i+1, 2+i, theme->col_icon);
+					drawPixel(loop_end_pos-1-LOOP_TRIANGLE_SIZE+i+1, 2+i, theme->col_outline);
 				}
 
-				drawHLine(loop_end_pos-2, LOOP_TRIANGLE_SIZE, 2, theme->col_icon);
+				drawHLine(loop_end_pos-2, LOOP_TRIANGLE_SIZE, 2, theme->col_outline);
 			}
 
 			// Right Triangle
 			if(loop_end_pos < width-1-LOOP_TRIANGLE_SIZE)
 			{
 				drawHLine(loop_end_pos+1, 1, LOOP_TRIANGLE_SIZE-1, theme->col_loop);
-				drawPixel(loop_end_pos+LOOP_TRIANGLE_SIZE, 1, theme->col_icon);
+				drawPixel(loop_end_pos+LOOP_TRIANGLE_SIZE, 1, theme->col_outline);
 
 				for(u8 i=0; i<LOOP_TRIANGLE_SIZE-2; ++i)
 				{
 					drawHLine(loop_end_pos+1, 2+i, LOOP_TRIANGLE_SIZE-i-1, theme->col_loop);
-					drawPixel(loop_end_pos+LOOP_TRIANGLE_SIZE-i, 2+i, theme->col_icon);
+					drawPixel(loop_end_pos+LOOP_TRIANGLE_SIZE-i, 2+i, theme->col_outline);
 				}
 
-				drawHLine(loop_end_pos+1, LOOP_TRIANGLE_SIZE, 2, theme->col_icon);
+				drawHLine(loop_end_pos+1, LOOP_TRIANGLE_SIZE, 2, theme->col_outline);
 			}
 		}
 	}
@@ -682,8 +683,8 @@ void SampleDisplay::draw(void)
 		// +
 		if(pen_on_zoom_in) {
 			drawFullBox(2, 2, 7, 7, theme->col_light_bg);
-			drawHLine(3, 5, 5, theme->col_dark_bg);
-			drawVLine(5, 3, 5, theme->col_dark_bg);
+			drawHLine(3, 5, 5, theme->col_smp_bg);
+			drawVLine(5, 3, 5, theme->col_smp_bg);
 		} else {
 			drawHLine(3, 5, 5, theme->col_light_bg);
 			drawVLine(5, 3, 5, theme->col_light_bg);
@@ -692,7 +693,7 @@ void SampleDisplay::draw(void)
 		// -
 		if(pen_on_zoom_out) {
 			drawFullBox(10, 2, 7, 7, theme->col_light_bg);
-			drawHLine(11, 5, 5, theme->col_dark_bg);
+			drawHLine(11, 5, 5, theme->col_smp_bg);
 		} else {
 			drawHLine(11, 5, 5, theme->col_light_bg);
 		}

--- a/themes/Default.nttheme
+++ b/themes/Default.nttheme
@@ -1,0 +1,45 @@
+203078 ; Background
+203078 ; Dark background
+485888 ; Medium background
+8090c0 ; Light background
+b8c8f8 ; Lighter background
+f8f800 ; Light control
+f89000 ; Dark control
+8090c0 ; Light control (disabled)
+485888 ; Dark control (disabled)
+e07800 ; List highlight 1
+e0e000 ; List highlight 2
+000000 ; Outline
+000000 ; Tab outline
+f8f800 ; List separator line
+000000 ; Icon
+000000 ; Text
+f80000 ; Recording/signal
+900000 ; Recording/signal (off)
+000000 ; Piano mapping label (naturals)
+f8f8f8 ; Piano mapping label, inverted (sharps)
+38c828 ; Loop handles
+00f800 ; Envelope sustain line
+88c080 ; Memory usage: OK
+f8f800 ; Memory usage: Warning
+f80000 ; Memory usage: Alert
+000000 ; Keyboard cursor
+8090c0 ; Pattern - lines
+384888 ; Pattern - sublines
+f89000 ; Pattern - lines (recording)
+485888 ; Pattern - Cursor bar color 1
+8090c0 ; Pattern - Cursor bar color 2
+e07800 ; Pattern - Cursor bar color 1 (highlight)
+e0e000 ; Pattern - Cursor bar color 2 (highlight)
+e07800 ; Pattern - Row numbers
+4878f8 ; Pattern - Notes
+0030d0 ; Pattern - Notes (dark)
+f85800 ; Pattern - Instruments
+a03000 ; Pattern - Instruments (dark)
+00d800 ; Pattern - Volume
+008000 ; Pattern - Volume (dark)
+f860e8 ; Pattern - Effect command
+603090 ; Pattern - Effect command (dark)
+f0d040 ; Pattern - Effect parameter
+484028 ; Pattern - Effect parameter (dark)
+f8c000 ; Pattern - Selection

--- a/themes/Default.nttheme
+++ b/themes/Default.nttheme
@@ -7,13 +7,19 @@ f8f800 ; Light control
 f89000 ; Dark control
 8090c0 ; Light control (disabled)
 485888 ; Dark control (disabled)
+485888 ; List item 1
+8090c0 ; List item 2
 e07800 ; List highlight 1
 e0e000 ; List highlight 2
 000000 ; Outline
 000000 ; Tab outline
 f8f800 ; List separator line
-000000 ; Icon
+000000 ; Tab icons
 000000 ; Text
+000000 ; Button text & button icons
+000000 ; Text (list items)
+000000 ; Text (value, e.g. number slider)
+000000 ; Text (selected list item)
 f80000 ; Recording/signal
 900000 ; Recording/signal (off)
 000000 ; Piano mapping label (naturals)
@@ -23,7 +29,8 @@ f8f8f8 ; Piano mapping label, inverted (sharps)
 88c080 ; Memory usage: OK
 f8f800 ; Memory usage: Warning
 f80000 ; Memory usage: Alert
-000000 ; Keyboard cursor
+000000 ; Typewriter cursor
+203078 ; Pattern - background
 8090c0 ; Pattern - lines
 384888 ; Pattern - sublines
 f89000 ; Pattern - lines (recording)

--- a/themes/Default.nttheme
+++ b/themes/Default.nttheme
@@ -1,52 +1,79 @@
-203078 ; Background
-203078 ; Dark background
-485888 ; Medium background
-8090c0 ; Light background
-b8c8f8 ; Lighter background
-f8f800 ; Light control
-f89000 ; Dark control
-8090c0 ; Light control (disabled)
-485888 ; Dark control (disabled)
-485888 ; List item 1
-8090c0 ; List item 2
-e07800 ; List highlight 1
-e0e000 ; List highlight 2
-000000 ; Outline
-000000 ; Tab outline
-f8f800 ; List separator line
-000000 ; Tab icons
-000000 ; Text
-000000 ; Button text & button icons
-000000 ; Text (list items)
-000000 ; Text (value, e.g. number slider)
-000000 ; Text (selected list item)
-f80000 ; Recording/signal
-900000 ; Recording/signal (off)
-000000 ; Piano mapping label (naturals)
-f8f8f8 ; Piano mapping label, inverted (sharps)
-38c828 ; Loop handles
-00f800 ; Envelope sustain line
-88c080 ; Memory usage: OK
-f8f800 ; Memory usage: Warning
-f80000 ; Memory usage: Alert
-000000 ; Typewriter cursor
-203078 ; Pattern - background
-8090c0 ; Pattern - lines
-384888 ; Pattern - sublines
-f89000 ; Pattern - lines (recording)
-485888 ; Pattern - Cursor bar color 1
-8090c0 ; Pattern - Cursor bar color 2
-e07800 ; Pattern - Cursor bar color 1 (highlight)
-e0e000 ; Pattern - Cursor bar color 2 (highlight)
-e07800 ; Pattern - Row numbers
-4878f8 ; Pattern - Notes
-0030d0 ; Pattern - Notes (dark)
-f85800 ; Pattern - Instruments
-a03000 ; Pattern - Instruments (dark)
-00d800 ; Pattern - Volume
-008000 ; Pattern - Volume (dark)
-f860e8 ; Pattern - Effect command
-603090 ; Pattern - Effect command (dark)
-f0d040 ; Pattern - Effect parameter
-484028 ; Pattern - Effect parameter (dark)
-f8c000 ; Pattern - Selection
+0=20317b  ; Background
+2=4a5a8b  ; Medium background
+3=8394c5  ; Light background
+4=bdcdff  ; Lighter background
+5=ffff00  ; Light control / button gradient 1
+6=ff9400  ; Dark control / button gradient 2
+7=8394c5  ; Light control (disabled)
+8=4a5a8b  ; Dark control (disabled)
+9=8394c5  ; Selected tab
+10=4a5a8b ; Unselected tab
+11=4a5a8b ; List item gradient 1
+12=8394c5 ; List item gradient 2
+13=e67b00 ; List item gradient 1 (highlighted)
+14=e6e600 ; List item gradient 2 (highlighted)
+15=4a5a8b ; Scrollbar background gradient 1
+16=8394c5 ; Scrollbar background gradient 2
+17=ff9400 ; Scrollbar thumb (inactive)
+18=ffff00 ; Scrollbar thumb (active)
+19=ff9400 ; Scrollbar arrow background gradient 1
+20=ffff00 ; Scrollbar arrow background gradient 2
+21=000000 ; Widget outline
+22=000000 ; Tab/tab box outline
+23=ffff00 ; List item separator line
+24=000000 ; Tab icon
+25=000000 ; Button icon and scrollbar arrows
+26=000000 ; Checkmark
+27=000000 ; Text
+28=8394c5 ; Text (light)
+29=000000 ; Text (buttons)
+30=000000 ; Text (value input)
+31=000000 ; Text (list items)
+32=000000 ; Text (highlighted list item)
+33=ff0000 ; Recording/signal (red)
+34=940000 ; Recording/signal (off, dark red)
+35=000000 ; Piano mapping label (naturals)
+36=ffffff ; Piano mapping label (inverted, sharps)
+37=39cd29 ; Loop points
+1=20317b  ; Envelope editor background
+38=00ff00 ; Envelope sustain line
+39=ff9400 ; Envelope line
+40=ffff00 ; Envelope point fill
+41=000000 ; Envelope point outline
+42=ff0000 ; Envelope point outline (active)
+43=8bc583 ; Memory usage: OK
+44=ffff00 ; Memory usage: Warning
+45=ff0000 ; Memory usage: Alert
+46=000000 ; Text entry cursor
+47=20317b ; Sample editor background
+48=ffff00 ; Sample editor background (selection)
+49=ff9c00 ; Sample editor waveform
+50=000000 ; Sample editor waveform (selection)
+51=20317b ; Pattern - background
+52=8394c5 ; Pattern - channel number
+53=8394c5 ; Pattern - lines
+54=394a8b ; Pattern - sublines
+55=ff9400 ; Pattern - lines (recording)
+56=4a5a8b ; Pattern - cursor bar gradient 1
+57=8394c5 ; Pattern - cursor bar gradient 2
+58=e67b00 ; Pattern - cursor bar gradient 1 (highlight)
+59=e6e600 ; Pattern - cursor bar gradient 2 (highlight)
+60=e67b00 ; Pattern - row numbers
+61=4a7bff ; Pattern - notes
+62=0031d5 ; Pattern - notes (dark)
+63=ff5a00 ; Pattern - instruments
+64=a43100 ; Pattern - instruments (dark)
+65=00de00 ; Pattern - volume
+66=008300 ; Patterm - volume (dark)
+67=ff62ee ; Pattern - effect command
+68=623194 ; Pattern - effect command (dark)
+69=f6d541 ; Pattern - effect parameter
+70=4a4129 ; Pattern - effect parameter (dark)
+71=ffc500 ; Pattern - selection
+72=000000 ; Pattern - row outline
+73=000000 ; Pattern - cursor outline
+74=000000 ; Pattern - mute/solo text color
+75=4a5a8b ; Pattern - mute/solo gradient 1
+76=8394c5 ; Pattern - mute/solo gradient 2
+77=e67b00 ; Pattern - mute/solo gradient 1 (highlight)
+78=e6e600 ; Pattern - mute/solo gradient 2 (highlight)

--- a/themes/Default.nttheme
+++ b/themes/Default.nttheme
@@ -12,6 +12,8 @@
 12=8394c5 ; List item gradient 2
 13=e67b00 ; List item gradient 1 (highlighted)
 14=e6e600 ; List item gradient 2 (highlighted)
+23=ffff00 ; List item separator line
+80=ffff00 ; List item separator line (vertical)
 15=4a5a8b ; Scrollbar background gradient 1
 16=8394c5 ; Scrollbar background gradient 2
 17=ff9400 ; Scrollbar thumb (inactive)
@@ -20,7 +22,6 @@
 20=ffff00 ; Scrollbar arrow background gradient 2
 21=000000 ; Widget outline
 22=000000 ; Tab/tab box outline
-23=ffff00 ; List item separator line
 24=000000 ; Tab icon
 25=000000 ; Button icon and scrollbar arrows
 26=000000 ; Checkmark
@@ -30,6 +31,9 @@
 30=000000 ; Text (value input)
 31=000000 ; Text (list items)
 32=000000 ; Text (highlighted list item)
+81=ff9400 ; Togglebutton background
+82=000000 ; Togglebutton text (off)
+83=ffff00 ; Togglebutton text (on)
 33=ff0000 ; Recording/signal (red)
 34=940000 ; Recording/signal (off, dark red)
 35=000000 ; Piano mapping label (naturals)
@@ -59,6 +63,7 @@
 58=e67b00 ; Pattern - cursor bar gradient 1 (highlight)
 59=e6e600 ; Pattern - cursor bar gradient 2 (highlight)
 60=e67b00 ; Pattern - row numbers
+79=e67b00 ; Pattern - row numbers (highlight)
 61=4a7bff ; Pattern - notes
 62=0031d5 ; Pattern - notes (dark)
 63=ff5a00 ; Pattern - instruments

--- a/tobkit/include/tobkit/theme.h
+++ b/tobkit/include/tobkit/theme.h
@@ -22,7 +22,7 @@ limitations under the License.
 #include "../../arm9/source/tools.h" 
 #include <nds.h>
 
-#define NUM_COLORS 45
+#define NUM_COLORS 52
 #define THEME_FILENAME_LEN 255
 
 namespace tobkit {
@@ -40,6 +40,8 @@ public:
 	u16 col_dark_ctrl;
 	u16 col_light_ctrl_disabled;
 	u16 col_dark_ctrl_disabled;
+	u16 col_list_1;
+	u16 col_list_2;
 	u16 col_list_highlight1;
 	u16 col_list_highlight2;
 	u16 col_outline;
@@ -47,6 +49,10 @@ public:
 	u16 col_sepline;
 	u16 col_icon;
 	u16 col_text;
+	u16 col_text_bt;
+	u16 col_text_2;
+	u16 col_text_lb;
+	u16 col_text_lb_highlight;
 	u16 col_signal;
 	u16 col_signal_off;
 	u16 col_piano_label;
@@ -57,6 +63,7 @@ public:
 	u16 col_mem_warn;
 	u16 col_mem_alert;
 	u16 col_typewriter_cursor;
+	u16 col_pv_bg;
 	u16 col_pv_lines;
 	u16 col_pv_sublines;
 	u16 col_pv_lines_record;
@@ -78,7 +85,8 @@ public:
 	u16 col_pv_cb_sel_highlight;
 private:
 	bool stringToRGB15(char* str, u16* col);
-	bool parseThemeConf(char* str, u16* theme_cols);
+	void RGB15ToString(u16 col, char* str);
+	bool parseTheme(FILE *theme, u16* theme_cols);
 	char themepath[THEME_FILENAME_LEN + 1];
 	bool fat;
 };

--- a/tobkit/include/tobkit/theme.h
+++ b/tobkit/include/tobkit/theme.h
@@ -22,7 +22,7 @@ limitations under the License.
 #include "../../arm9/source/tools.h" 
 #include <nds.h>
 
-#define NUM_COLORS 79
+#define NUM_COLORS 84
 #define THEME_FILENAME_LEN 255
 
 namespace tobkit {
@@ -110,6 +110,12 @@ public:
 	u16 col_pv_mutesolo_col2;
 	u16 col_pv_mutesolo_col1_highlight;
 	u16 col_pv_mutesolo_col2_highlight;
+	u16 col_pv_left_numbers_highlight;
+	u16 col_list_sep_vertical;
+	u16 col_tb_bg;
+	u16 col_tb_fg_off;
+	u16 col_tb_fg_on;
+
 private:
 	bool stringToRGB15(char* str, u16* col);
 	void RGB15ToString(u16 col, char* str);

--- a/tobkit/include/tobkit/theme.h
+++ b/tobkit/include/tobkit/theme.h
@@ -22,7 +22,7 @@ limitations under the License.
 #include "../../arm9/source/tools.h" 
 #include <nds.h>
 
-#define NUM_COLORS 52
+#define NUM_COLORS 79
 #define THEME_FILENAME_LEN 255
 
 namespace tobkit {
@@ -32,7 +32,7 @@ public:
 	void read(void);
 
 	u16 col_bg;
-	u16 col_dark_bg;
+	u16 col_env_bg;
 	u16 col_medium_bg;
 	u16 col_light_bg;
 	u16 col_lighter_bg;
@@ -40,17 +40,28 @@ public:
 	u16 col_dark_ctrl;
 	u16 col_light_ctrl_disabled;
 	u16 col_dark_ctrl_disabled;
+	u16 col_selected_tab;
+	u16 col_unselected_tab;
 	u16 col_list_1;
 	u16 col_list_2;
 	u16 col_list_highlight1;
 	u16 col_list_highlight2;
+	u16 col_scrollbar_bg1;
+	u16 col_scrollbar_bg2;
+	u16 col_scrollbar_inactive;
+	u16 col_scrollbar_active;
+	u16 col_scrollbar_arr_bg1;
+	u16 col_scrollbar_arr_bg2;
 	u16 col_outline;
 	u16 col_tab_outline;
 	u16 col_sepline;
 	u16 col_icon;
+	u16 col_icon_bt;
+	u16 col_checkmark;
 	u16 col_text;
+	u16 col_text_light;
 	u16 col_text_bt;
-	u16 col_text_2;
+	u16 col_text_value;
 	u16 col_text_lb;
 	u16 col_text_lb_highlight;
 	u16 col_signal;
@@ -59,11 +70,20 @@ public:
 	u16 col_piano_label_inv;
 	u16 col_loop;
 	u16 col_env_sustain;
+	u16 col_env_line;
+	u16 col_env_pt;
+	u16 col_env_pt_border;
+	u16 col_env_pt_border_active;
 	u16 col_mem_ok;
 	u16 col_mem_warn;
 	u16 col_mem_alert;
 	u16 col_typewriter_cursor;
+	u16 col_smp_bg;
+	u16 col_smp_bg_sel;
+	u16 col_smp_waveform;
+	u16 col_smp_waveform_sel;
 	u16 col_pv_bg;
+	u16 col_pv_chn;
 	u16 col_pv_lines;
 	u16 col_pv_sublines;
 	u16 col_pv_lines_record;
@@ -83,6 +103,13 @@ public:
 	u16 col_pv_effect_param;
 	u16 col_pv_effect_param_dark;
 	u16 col_pv_cb_sel_highlight;
+	u16 col_pv_pb;
+	u16 col_pv_pb_cell;
+	u16 col_pv_mutesolo_text;
+	u16 col_pv_mutesolo_col1;
+	u16 col_pv_mutesolo_col2;
+	u16 col_pv_mutesolo_col1_highlight;
+	u16 col_pv_mutesolo_col2_highlight;
 private:
 	bool stringToRGB15(char* str, u16* col);
 	void RGB15ToString(u16 col, char* str);

--- a/tobkit/include/tobkit/theme.h
+++ b/tobkit/include/tobkit/theme.h
@@ -14,65 +14,74 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ======================================================================*/
 
-#ifndef _THEME_H_
-#define _THEME_H_
+  // Themes
 
+#ifndef THEME_H
+#define THEME_H
+
+#include "../../arm9/source/tools.h" 
 #include <nds.h>
 
+#define NUM_COLORS 45
+#define THEME_FILENAME_LEN 255
+
 namespace tobkit {
+class Theme {
+public:
+	Theme(char* themepath = NULL, bool use_fat = true);
+	void read(void);
 
-class Theme
-{
-	public:
-		Theme();
-		
-		u16 col_bg;
-		u16 col_dark_bg;
-		u16 col_medium_bg;
-		u16 col_light_bg;
-		u16 col_lighter_bg;
-		u16 col_light_ctrl;
-		u16 col_dark_ctrl;
-		u16 col_light_ctrl_disabled;
-		u16 col_dark_ctrl_disabled;
-		u16 col_list_highlight1;
-		u16 col_list_highlight2;
-		u16 col_outline;
-		u16 col_tab_outline;
-		u16 col_sepline;
-		u16 col_icon;
-		u16 col_text;
-		u16 col_signal;
-		u16 col_signal_off;
-		u16 col_piano_label;
-		u16 col_piano_label_inv;
-		u16 col_loop;
-		u16 col_env_sustain;
-		u16 col_mem_ok;
-		u16 col_mem_warn;
-		u16 col_mem_alert;
-		u16 col_typewriter_cursor;
-		u16 col_pv_lines;
-		u16	col_pv_sublines;
-		u16	col_pv_lines_record;
-		u16 col_pv_cb_col1;
-		u16 col_pv_cb_col2;
-		u16	col_pv_cb_col1_highlight;
-		u16	col_pv_cb_col2_highlight;
-		u16 col_pv_left_numbers;
-		u16 col_pv_notes;
-		u16 col_pv_instr;
-		u16 col_pv_volume;
-		u16 col_pv_effect;
-		u16 col_pv_effect_param;
-		u16 col_pv_notes_dark;
-		u16 col_pv_instr_dark;
-		u16 col_pv_volume_dark;
-		u16 col_pv_effect_dark;
-		u16 col_pv_effect_param_dark;
-		u16 col_pv_cb_sel_highlight;
+	u16 col_bg;
+	u16 col_dark_bg;
+	u16 col_medium_bg;
+	u16 col_light_bg;
+	u16 col_lighter_bg;
+	u16 col_light_ctrl;
+	u16 col_dark_ctrl;
+	u16 col_light_ctrl_disabled;
+	u16 col_dark_ctrl_disabled;
+	u16 col_list_highlight1;
+	u16 col_list_highlight2;
+	u16 col_outline;
+	u16 col_tab_outline;
+	u16 col_sepline;
+	u16 col_icon;
+	u16 col_text;
+	u16 col_signal;
+	u16 col_signal_off;
+	u16 col_piano_label;
+	u16 col_piano_label_inv;
+	u16 col_loop;
+	u16 col_env_sustain;
+	u16 col_mem_ok;
+	u16 col_mem_warn;
+	u16 col_mem_alert;
+	u16 col_typewriter_cursor;
+	u16 col_pv_lines;
+	u16 col_pv_sublines;
+	u16 col_pv_lines_record;
+	u16 col_pv_cb_col1;
+	u16 col_pv_cb_col2;
+	u16 col_pv_cb_col1_highlight;
+	u16 col_pv_cb_col2_highlight;
+	u16 col_pv_left_numbers;
+	u16 col_pv_notes;
+	u16 col_pv_notes_dark;
+	u16 col_pv_instr;
+	u16 col_pv_instr_dark;
+	u16 col_pv_volume;
+	u16 col_pv_volume_dark;
+	u16 col_pv_effect;
+	u16 col_pv_effect_dark;
+	u16 col_pv_effect_param;
+	u16 col_pv_effect_param_dark;
+	u16 col_pv_cb_sel_highlight;
+private:
+	bool stringToRGB15(char* str, u16* col);
+	bool parseThemeConf(char* str, u16* theme_cols);
+	char themepath[THEME_FILENAME_LEN + 1];
+	bool fat;
 };
 
 };
-
 #endif

--- a/tobkit/include/tobkit/widget.h
+++ b/tobkit/include/tobkit/widget.h
@@ -129,8 +129,8 @@ class Widget {
 			)|BIT(15);
 		}
 
-		void drawMonochromeIcon(u8 tx, u8 ty, u8 tw, u8 th, const u8 *icon, u16 color=RGB15(0,0,0)|BIT(15));
-		void drawMonochromeIconOffset(u8 tx, u8 ty, u8 tw, u8 th, u8 ix, u8 iy, u8 iw, u8 ih, const u8 *icon, u16 color=RGB15(0,0,0)|BIT(15));
+		void drawMonochromeIcon(u8 tx, u8 ty, u8 tw, u8 th, const u8 *icon, u16 color);
+		void drawMonochromeIconOffset(u8 tx, u8 ty, u8 tw, u8 th, u8 ix, u8 iy, u8 iw, u8 ih, const u8 *icon, u16 color);
 
 		// Stylus utility functions
 		bool isInRect(u8 x, u8 y, u8 x1, u8 y1, u8 x2, u8 y2);

--- a/tobkit/source/bitbutton.cpp
+++ b/tobkit/source/bitbutton.cpp
@@ -86,5 +86,5 @@ void BitButton::draw(u8 down)
 	}
 	drawBorder(theme->col_outline);
 
-	drawMonochromeIcon(bmpx, bmpy, bmpwidth, bmpheight, bitmap, theme->col_icon);
+	drawMonochromeIcon(bmpx, bmpy, bmpwidth, bmpheight, bitmap, theme->col_text_bt);
 }

--- a/tobkit/source/bitbutton.cpp
+++ b/tobkit/source/bitbutton.cpp
@@ -86,5 +86,5 @@ void BitButton::draw(u8 down)
 	}
 	drawBorder(theme->col_outline);
 
-	drawMonochromeIcon(bmpx, bmpy, bmpwidth, bmpheight, bitmap, theme->col_text_bt);
+	drawMonochromeIcon(bmpx, bmpy, bmpwidth, bmpheight, bitmap, theme->col_icon_bt);
 }

--- a/tobkit/source/bitbutton.cpp
+++ b/tobkit/source/bitbutton.cpp
@@ -86,5 +86,5 @@ void BitButton::draw(u8 down)
 	}
 	drawBorder(theme->col_outline);
 
-	drawMonochromeIcon(bmpx, bmpy, bmpwidth, bmpheight, bitmap);
+	drawMonochromeIcon(bmpx, bmpy, bmpwidth, bmpheight, bitmap, theme->col_icon);
 }

--- a/tobkit/source/button.cpp
+++ b/tobkit/source/button.cpp
@@ -94,5 +94,5 @@ void Button::draw(u8 down) {
 	}
 	drawBorder(theme->col_outline);
 	
-	drawString(caption, (width-getStringWidth(caption))/2, height/2-5, theme->col_text);
+	drawString(caption, (width-getStringWidth(caption))/2, height/2-5, theme->col_text_bt);
 }

--- a/tobkit/source/checkbox.cpp
+++ b/tobkit/source/checkbox.cpp
@@ -99,7 +99,7 @@ void CheckBox::draw(void)
 	
 	// Checked or not
 	if(checked == true)
-		drawMonochromeIcon(1, 0, 10, 10, haken_raw);
+		drawMonochromeIcon(1, 0, 10, 10, haken_raw, theme->col_icon);
 	
 	// Text
 	if(!albino)

--- a/tobkit/source/checkbox.cpp
+++ b/tobkit/source/checkbox.cpp
@@ -95,15 +95,15 @@ void CheckBox::draw(void)
 	if(!albino)
 		drawFullBox(0, 0, 11, 3, theme->col_light_bg);
 	else
-		drawFullBox(0, 0, 11, 3, theme->col_dark_bg);
+		drawFullBox(0, 0, 11, 3, theme->col_bg);
 	
 	// Checked or not
 	if(checked == true)
-		drawMonochromeIcon(1, 0, 10, 10, haken_raw, theme->col_icon);
+		drawMonochromeIcon(1, 0, 10, 10, haken_raw, theme->col_checkmark);
 	
 	// Text
 	if(!albino)
 		drawString(label, 13, 2, theme->col_text);
 	else
-		drawString(label, 13, 2, theme->col_lighter_bg);
+		drawString(label, 13, 2, theme->col_text_light);
 }

--- a/tobkit/source/gradienticon.cpp
+++ b/tobkit/source/gradienticon.cpp
@@ -68,7 +68,7 @@ void GradientIcon::draw(void)
 				pixel >>= 2;
 			}
 			if(pixel & 3)
-				(*vram)[SCREEN_WIDTH*(y+j)+x+i] = (pixel & 2) ? 0x000000 : colorFg;
+				(*vram)[SCREEN_WIDTH*(y+j)+x+i] = (pixel & 2) ? theme->col_outline : colorFg;
 		}
 	}
 }

--- a/tobkit/source/label.cpp
+++ b/tobkit/source/label.cpp
@@ -82,8 +82,8 @@ void Label::draw(void)
 	u16 col_bg, col_text;
 	if(is_albino)
 	{
-		col_bg = theme->col_dark_bg;
-		col_text = theme->col_lighter_bg;
+		col_bg = theme->col_bg;
+		col_text = theme->col_text_light;
 	}
 	else
 	{
@@ -98,7 +98,7 @@ void Label::draw(void)
 	{
 		if(!no_bg) {
 			drawFullBox(1, 1, width - 2, height - 2, theme->col_lighter_bg);
-			col_text = theme->col_text_2; 
+			col_text = theme->col_text_value; 
 		}
 
 		drawBorder(theme->col_outline);

--- a/tobkit/source/label.cpp
+++ b/tobkit/source/label.cpp
@@ -96,11 +96,15 @@ void Label::draw(void)
 
 	if(has_border)
 	{
-		if(!no_bg)
+		if(!no_bg) {
 			drawFullBox(1, 1, width - 2, height - 2, theme->col_lighter_bg);
+			col_text = theme->col_text_2; 
+		}
+
 		drawBorder(theme->col_outline);
 		caption_x_offset += 2;
 		caption_y_offset += 2;
+		
 	}
 	else
 	{

--- a/tobkit/source/listbox.cpp
+++ b/tobkit/source/listbox.cpp
@@ -285,8 +285,8 @@ void ListBox::draw(void)
 	
 	// Fill rows
 	for(i=0;i<rows_displayed;++i) {
-		u16 col_bottom = theme->col_medium_bg;
-		u16 col_top = theme->col_light_bg;
+		u16 col_bottom = theme->col_list_1;
+		u16 col_top = theme->col_list_2;
 		if((scrollpos+i)==activeelement) {
 			col_bottom = theme->col_list_highlight1;
 			col_top = theme->col_list_highlight2;
@@ -365,7 +365,8 @@ void ListBox::draw(void)
 		}
 		for(i=0;(i<height/ROW_HEIGHT)&&(scrollpos+i<elements.size());++i) {
 			snprintf(numberstr, sizeof(numberstr), "%2x", (u16) (scrollpos+i+offset));
-			drawString(numberstr, 2, ROW_HEIGHT*i+2, theme->col_text);
+			drawString(numberstr, 2, ROW_HEIGHT*i+2, 
+			scrollpos+i == activeelement ? theme->col_text_lb_highlight : theme->col_text_lb);
 		}
 		
 		contentoffset = COUNTER_WIDTH;
@@ -376,7 +377,7 @@ void ListBox::draw(void)
 	// Content
 	for(i=0;(i<height/ROW_HEIGHT)&&(scrollpos+i<elements.size());++i) {
 		drawString(elements.at(scrollpos+i).c_str(), contentoffset+2, ROW_HEIGHT*i+2,
-			theme->col_text,
+			scrollpos+i == activeelement ? theme->col_text_lb_highlight : theme->col_text_lb,
 			width-contentoffset-2-SCROLLBAR_WIDTH-2,
 			height-(ROW_HEIGHT*i+4)
 		);

--- a/tobkit/source/listbox.cpp
+++ b/tobkit/source/listbox.cpp
@@ -299,7 +299,7 @@ void ListBox::draw(void)
 
 	// Vertical number separator line
 	if(show_numbers) {
-		drawVLine(COUNTER_WIDTH,1,height-2,theme->col_sepline);
+		drawVLine(COUNTER_WIDTH,1,height-2,theme->col_list_sep_vertical);
 	}
 	
 	// Scrollbar

--- a/tobkit/source/listbox.cpp
+++ b/tobkit/source/listbox.cpp
@@ -305,9 +305,9 @@ void ListBox::draw(void)
 	// Scrollbar
 	// Upper Button
 	if(buttonstate==SCROLLUP) {
-		drawGradient(theme->col_dark_ctrl, theme->col_light_ctrl, width-SCROLLBAR_WIDTH+1, 1, 8, 8);
+		drawGradient(theme->col_scrollbar_arr_bg1, theme->col_scrollbar_arr_bg2, width-SCROLLBAR_WIDTH+1, 1, 8, 8);
 	} else {
-		drawGradient(theme->col_light_ctrl, theme->col_dark_ctrl, width-SCROLLBAR_WIDTH+1, 1, 8, 8);
+		drawGradient(theme->col_scrollbar_arr_bg2, theme->col_scrollbar_arr_bg1, width-SCROLLBAR_WIDTH+1, 1, 8, 8);
 	}
 	
 	// This draws the up-arrow
@@ -322,9 +322,9 @@ void ListBox::draw(void)
 	
 	// Lower Button
 	if(buttonstate==SCROLLDOWN) {
-		drawGradient(theme->col_dark_ctrl, theme->col_light_ctrl, width-SCROLLBAR_WIDTH+1, height-9, 8, 8);
+		drawGradient(theme->col_scrollbar_arr_bg1, theme->col_scrollbar_arr_bg2, width-SCROLLBAR_WIDTH+1, height-9, 8, 8);
 	} else {
-		drawGradient(theme->col_light_ctrl, theme->col_dark_ctrl, width-SCROLLBAR_WIDTH+1, height-9, 8, 8);
+		drawGradient(theme->col_scrollbar_arr_bg2, theme->col_scrollbar_arr_bg1, width-SCROLLBAR_WIDTH+1, height-9, 8, 8);
 	}
 	
 	// This draws the down-arrow
@@ -339,15 +339,15 @@ void ListBox::draw(void)
 	drawBox(width-SCROLLBAR_WIDTH, 0, SCROLLBAR_WIDTH, height, theme->col_outline);
 	
 	// Clear Scrollbar
-	drawGradient(theme->col_medium_bg, theme->col_light_bg, width-SCROLLBAR_WIDTH+1, SCROLLBUTTON_HEIGHT, SCROLLBAR_WIDTH-2, height-2*SCROLLBUTTON_HEIGHT);
+	drawGradient(theme->col_scrollbar_bg1, theme->col_scrollbar_bg2, width-SCROLLBAR_WIDTH+1, SCROLLBUTTON_HEIGHT, SCROLLBAR_WIDTH-2, height-2*SCROLLBUTTON_HEIGHT);
 
 	if (height >= 2*SCROLLBUTTON_HEIGHT+scrollthingyheight) {
 	
 		// The scroll thingy
 		if(buttonstate==SCROLLTHINGY) {
-			drawFullBox(width-SCROLLBAR_WIDTH+1, SCROLLBUTTON_HEIGHT-1+scrollthingypos, SCROLLBAR_WIDTH-2, scrollthingyheight, theme->col_list_highlight2);
+			drawFullBox(width-SCROLLBAR_WIDTH+1, SCROLLBUTTON_HEIGHT-1+scrollthingypos, SCROLLBAR_WIDTH-2, scrollthingyheight, theme->col_scrollbar_active);
 		} else {
-			drawFullBox(width-SCROLLBAR_WIDTH+1, SCROLLBUTTON_HEIGHT-1+scrollthingypos, SCROLLBAR_WIDTH-2, scrollthingyheight, theme->col_list_highlight1);
+			drawFullBox(width-SCROLLBAR_WIDTH+1, SCROLLBUTTON_HEIGHT-1+scrollthingypos, SCROLLBAR_WIDTH-2, scrollthingyheight, theme->col_scrollbar_inactive);
 		}
 		drawBox(width-SCROLLBAR_WIDTH, SCROLLBUTTON_HEIGHT+scrollthingypos-1, SCROLLBAR_WIDTH, scrollthingyheight, theme->col_outline);
 	}

--- a/tobkit/source/numberbox.cpp
+++ b/tobkit/source/numberbox.cpp
@@ -100,7 +100,7 @@ void NumberBox::draw(void)
 	int_fast8_t i,j;
 	for(j=0;j<3;j++) {
 		for(i=-j;i<=j;++i) {
-			drawPixel(4+i, j+3, theme->col_icon);
+			drawPixel(4+i, j+3, theme->col_text_bt);
 		}
 	}
 	
@@ -116,7 +116,7 @@ void NumberBox::draw(void)
 	// This draws the down-arrow
 	for(j=2;j>=0;j--) {
 		for(i=-j;i<=j;++i) {
-			drawPixel(4+i, -j+13, theme->col_icon);
+			drawPixel(4+i, -j+13, theme->col_text_bt);
 		}
 	}
 	
@@ -131,7 +131,7 @@ void NumberBox::draw(void)
 	formatstr[1] = digits+48;
 	
 	snprintf(numberstr, sizeof(numberstr), formatstr, value);
-	drawString(numberstr, 10, 5, theme->col_text);
+	drawString(numberstr, 10, 5, theme->col_text_2);
 	
 	// Border
 	drawBorder(theme->col_outline);

--- a/tobkit/source/numberbox.cpp
+++ b/tobkit/source/numberbox.cpp
@@ -131,7 +131,7 @@ void NumberBox::draw(void)
 	formatstr[1] = digits+48;
 	
 	snprintf(numberstr, sizeof(numberstr), formatstr, value);
-	drawString(numberstr, 10, 5, theme->col_text_2);
+	drawString(numberstr, 10, 5, theme->col_text_value);
 	
 	// Border
 	drawBorder(theme->col_outline);

--- a/tobkit/source/numberslider.cpp
+++ b/tobkit/source/numberslider.cpp
@@ -161,17 +161,17 @@ void NumberSlider::draw(void)
 	int_fast8_t i,j;
 	for(j=0;j<3;j++) {
 		for(i=-j;i<=j;++i) {
-			drawPixel(4+i, j+3, theme->col_icon);
+			drawPixel(4+i, j+3, theme->col_text_bt);
 		}
 	}
 	
 	// This draws the connection
-	drawVLine(4, 6, 5, theme->col_icon);
+	drawVLine(4, 6, 5, theme->col_text_bt);
 	
 	// This draws the down-arrow
 	for(j=2;j>=0;j--) {
 		for(i=-j;i<=j;++i) {
-			drawPixel(4+i, -j+13, theme->col_icon);
+			drawPixel(4+i, -j+13, theme->col_text_bt);
 		}
 	}
 	
@@ -186,7 +186,7 @@ void NumberSlider::draw(void)
 	} else {
 		snprintf(numberstr, sizeof(numberstr), hex ? "%2lx" : "%3ld", value);
 	}
-	drawString(numberstr, 10, 5, theme->col_text);
+	drawString(numberstr, 10, 5, theme->col_text_2);
 	
 	// Border
 	drawBorder(theme->col_outline);

--- a/tobkit/source/numberslider.cpp
+++ b/tobkit/source/numberslider.cpp
@@ -186,7 +186,7 @@ void NumberSlider::draw(void)
 	} else {
 		snprintf(numberstr, sizeof(numberstr), hex ? "%2lx" : "%3ld", value);
 	}
-	drawString(numberstr, 10, 5, theme->col_text_2);
+	drawString(numberstr, 10, 5, theme->col_text_value);
 	
 	// Border
 	drawBorder(theme->col_outline);

--- a/tobkit/source/numberslider.cpp
+++ b/tobkit/source/numberslider.cpp
@@ -166,7 +166,7 @@ void NumberSlider::draw(void)
 	}
 	
 	// This draws the connection
-	drawVLine(4, 6, 5, theme->col_outline);
+	drawVLine(4, 6, 5, theme->col_icon);
 	
 	// This draws the down-arrow
 	for(j=2;j>=0;j--) {

--- a/tobkit/source/tabbox.cpp
+++ b/tobkit/source/tabbox.cpp
@@ -170,16 +170,16 @@ void TabBox::draw(void)
 	if (orientation == TABBOX_ORIENTATION_TOP) {
 		// Draw box
 		drawFullBox(1, size_full+1, width-2, height-(size_border+2), theme->col_light_bg);
-		drawBox(0, size_border, width, height-size_border, theme->col_outline);
+		drawBox(0, size_border, width, height-size_border, theme->col_tab_outline);
 		
 		// Draw tabs
-		drawFullBox(0, 0, 3+size_full*guis.size(), 3, theme->col_dark_bg);
+		drawFullBox(0, 0, 3+size_full*guis.size(), 3, theme->col_bg);
 		
 		for(u8 guiidx=0;guiidx<guis.size();++guiidx) {
 			bool selected = guiidx==currentgui;
 			u8 offset = selected ? 0 : 3;
 
-			drawFullBox(3+size_full*guiidx, 1+offset, size_border, size_border-offset, selected ? theme->col_light_bg : theme->col_medium_bg);
+			drawFullBox(3+size_full*guiidx, 1+offset, size_border, size_border-offset, selected ? theme->col_selected_tab : theme->col_unselected_tab);
 			drawVLine(2+size_full*guiidx, 1+offset, size_border-offset, black);
 			drawHLine(3+size_full*guiidx, 0+offset, size_border, black);
 			drawVLine(2+size_full*(guiidx+1), 1+offset, size_border-offset, black);
@@ -188,7 +188,7 @@ void TabBox::draw(void)
 	} else {
 		// Draw box
 		drawFullBox(14, 1, width-15, height-2, theme->col_light_bg);
-		drawBox(13, 0, width-13, height, theme->col_outline);
+		drawBox(13, 0, width-13, height, theme->col_tab_outline);
 
 		// Draw tabs
 		drawFullBox(0, 0, 3, 3+13*guis.size(), theme->col_light_bg);
@@ -197,7 +197,7 @@ void TabBox::draw(void)
 			bool selected = guiidx==currentgui;
 			u8 offset = selected ? 3 : 0;
 
-			drawFullBox(1+offset, 2+size_full*guiidx, size_border-offset, size_border, selected ? theme->col_medium_bg : theme->col_light_bg);
+			drawFullBox(1+offset, 2+size_full*guiidx, size_border-offset, size_border, selected ? theme->col_unselected_tab : theme->col_selected_tab);
 			drawHLine(1+offset, 2+size_full*guiidx, size_border-offset, black);
 			drawVLine(0+offset, 3+size_full*guiidx, size_border - 1, black);
 			drawHLine(1+offset, 2+size_full*(guiidx+1), size_border-offset, black);

--- a/tobkit/source/tabbox.cpp
+++ b/tobkit/source/tabbox.cpp
@@ -183,7 +183,7 @@ void TabBox::draw(void)
 			drawVLine(2+size_full*guiidx, 1+offset, size_border-offset, black);
 			drawHLine(3+size_full*guiidx, 0+offset, size_border, black);
 			drawVLine(2+size_full*(guiidx+1), 1+offset, size_border-offset, black);
-			drawMonochromeIcon(4+size_full*guiidx, 2+offset, icon_size, icon_size - offset, icons.at(guiidx));
+			drawMonochromeIcon(4+size_full*guiidx, 2+offset, icon_size, icon_size - offset, icons.at(guiidx), theme->col_icon);
 		}
 	} else {
 		// Draw box
@@ -201,7 +201,7 @@ void TabBox::draw(void)
 			drawHLine(1+offset, 2+size_full*guiidx, size_border-offset, black);
 			drawVLine(0+offset, 3+size_full*guiidx, size_border - 1, black);
 			drawHLine(1+offset, 2+size_full*(guiidx+1), size_border-offset, black);
-			drawMonochromeIconOffset(2+offset, 4+size_full*guiidx, icon_size - offset, icon_size, 0, 0, icon_size, icon_size, icons.at(guiidx));
+			drawMonochromeIconOffset(2+offset, 4+size_full*guiidx, icon_size - offset, icon_size, 0, 0, icon_size, icon_size, icons.at(guiidx), theme->col_icon);
 		}
 	}
 	

--- a/tobkit/source/theme.cpp
+++ b/tobkit/source/theme.cpp
@@ -15,57 +15,196 @@ limitations under the License.
 ======================================================================*/
 
 #include "tobkit/theme.h"
+#include <stdio.h>
+#include <string.h>
 
 using namespace tobkit;
 
-Theme::Theme(void)
-{
+Theme::Theme(char* themepath, bool use_fat) : 
 	// Set default colors
-	col_bg                  = RGB15(4,6,15)|BIT(15);
-	col_dark_bg             = col_bg;
-	col_medium_bg           = RGB15(9,11,17)|BIT(15);
-	col_light_bg            = RGB15(16,18,24)|BIT(15);
-	col_lighter_bg          = RGB15(23,25,31) | BIT(15);
-	col_light_ctrl          = RGB15(31,31,0)|BIT(15); // RGB15(26,26,26)|BIT(15)
-	col_dark_ctrl           = RGB15(31,18,0)|BIT(15); // RGB15(31,31,31)|BIT(15)
-	col_light_ctrl_disabled = col_light_bg;
-	col_dark_ctrl_disabled  = col_medium_bg;
-	col_list_highlight1     = RGB15(28,15,0)|BIT(15);
-	col_list_highlight2     = RGB15(28,28,0)|BIT(15);
-	col_outline             = RGB15(0,0,0)|BIT(15);
-	col_tab_outline			= col_outline;
-	col_sepline             = RGB15(31,31,0)|BIT(15);
-	col_icon                = RGB15(0,0,0)|BIT(15);
-	col_text                = RGB15(0,0,0)|BIT(15);
-	col_signal              = RGB15(31,0,0)|BIT(15);
-	col_signal_off			= RGB15(18, 0, 0) | BIT(15);
-	col_piano_label			= RGB15(0, 0, 0);
-	col_piano_label_inv		= RGB15(31,31,31);
-	col_loop				= RGB15(7,25,5)|BIT(15);
-	col_env_sustain			= RGB15(0,31,0) | BIT(15);
+	col_bg(RGB15(4, 6, 15) | BIT(15)),
+	col_dark_bg(col_bg),
+	col_medium_bg(RGB15(9, 11, 17) | BIT(15)),
+	col_light_bg(RGB15(16, 18, 24) | BIT(15)),
+	col_lighter_bg(RGB15(23, 25, 31) | BIT(15)),
+	col_light_ctrl(RGB15(31, 31, 0) | BIT(15)), // RGB15(26,26,26)|BIT(15)
+	col_dark_ctrl(RGB15(31, 18, 0) | BIT(15)),
+	col_light_ctrl_disabled(col_light_bg),
+	col_dark_ctrl_disabled(col_medium_bg),
+	col_list_highlight1(RGB15(28, 15, 0) | BIT(15)),
+	col_list_highlight2(RGB15(28, 28, 0) | BIT(15)),
+	col_outline(RGB15(0, 0, 0) | BIT(15)),
+	col_tab_outline(col_outline),
+	col_sepline(RGB15(31, 31, 0) | BIT(15)),
+	col_icon(RGB15(0, 0, 0) | BIT(15)),
+	col_text(RGB15(0, 0, 0) | BIT(15)),
+	col_signal(RGB15(31, 0, 0) | BIT(15)),
+	col_signal_off(RGB15(18, 0, 0) | BIT(15)),
+	col_piano_label(RGB15(0, 0, 0)),
+	col_piano_label_inv(RGB15(31, 31, 31)),
+	col_loop(RGB15(7, 25, 5) | BIT(15)),
+	col_env_sustain(RGB15(0, 31, 0) | BIT(15)),
+	col_mem_ok(RGB15(17, 24, 16) | BIT(15)),
+	col_mem_warn(RGB15(31, 31, 0) | BIT(15)),
+	col_mem_alert(RGB15(31, 0, 0) | BIT(15)),
+	col_typewriter_cursor(RGB15(0, 0, 0) | BIT(15)),
+	col_pv_lines(col_light_bg),
+	col_pv_sublines(RGB15(7, 9, 17) | BIT(15)),
+	col_pv_lines_record(col_dark_ctrl),
+	col_pv_cb_col1(col_medium_bg),
+	col_pv_cb_col2(col_light_bg),
+	col_pv_cb_col1_highlight(col_list_highlight1),
+	col_pv_cb_col2_highlight(col_list_highlight2),
+	col_pv_left_numbers(col_list_highlight1),
+	col_pv_notes(RGB15(9, 15, 31) | BIT(15)),
+	col_pv_notes_dark(RGB15(0, 6, 26) | BIT(15)),
+	col_pv_instr(RGB15(31, 11, 0) | BIT(15)),
+	col_pv_instr_dark(RGB15(20, 6, 0) | BIT(15)),
+	col_pv_volume(RGB15(0, 27, 0) | BIT(15)),
+	col_pv_volume_dark(RGB15(0, 16, 0) | BIT(15)),
+	col_pv_effect(RGB15(31, 12, 29) | BIT(15)),
+	col_pv_effect_dark(RGB15(12, 6, 18) | BIT(15)),
+	col_pv_effect_param(RGB15(30, 26, 8) | BIT(15)),
+	col_pv_effect_param_dark(RGB15(9, 8, 5) | BIT(15)),
+	col_pv_cb_sel_highlight(RGB15(31, 24, 0) | BIT(15)), fat(use_fat)
+{
+	if (fat == true && themepath != NULL)
+	{
+		FILE* conf = fopen(themepath, "r");
+		debugprintf("loading theme '%s'\n", themepath);
 
-	col_mem_ok				= RGB15(17,24,16) | BIT(15);
-	col_mem_warn			= RGB15(31,31,0) | BIT(15);
-	col_mem_alert			= RGB15(31,0,0) | BIT(15);
-	col_typewriter_cursor   = RGB15(0,0,0)|BIT(15);
-	col_pv_lines			= col_light_bg;
-	col_pv_sublines			= RGB15(7,9,17)|BIT(15);
-	col_pv_lines_record		= col_dark_ctrl;
-	col_pv_cb_col1			= col_medium_bg;
-	col_pv_cb_col2			= col_light_bg;
-	col_pv_cb_col1_highlight= col_list_highlight1;
-	col_pv_cb_col2_highlight= col_list_highlight2;
-	col_pv_left_numbers		= col_list_highlight1;
-	col_pv_notes			= RGB15(9,15,31)|BIT(15);
-	col_pv_notes_dark		= RGB15(0,6,26)|BIT(15);
-	col_pv_instr			= RGB15(31,11,0)|BIT(15);
-	col_pv_instr_dark		= RGB15(20,6,0)|BIT(15);
-	col_pv_volume			= RGB15(0,27,0)|BIT(15);
-	col_pv_volume_dark		= RGB15(0,16,0)|BIT(15);
-	col_pv_effect			= RGB15(31,12,29)|BIT(15);
-	col_pv_effect_dark		= RGB15(12,6,18)|BIT(15);
-	col_pv_effect_param		= RGB15(30,26,8)|BIT(15);
-	col_pv_effect_param_dark= RGB15(9,8,5)|BIT(15);
-	col_pv_cb_sel_highlight	= RGB15(31,24,0)|BIT(15);
+		if (conf != NULL)  {
+			fseek(conf, 0, SEEK_END);
+			u32 conf_filesize = ftell(conf);
+			fseek(conf, 0, SEEK_SET);
 
+			char* confstr = (char*)calloc(1, conf_filesize);
+			fread(confstr, conf_filesize, 1, conf);
+			fclose(conf);
+
+			u16* colscheme = (u16*)calloc(NUM_COLORS, sizeof(u16));
+			bool result = parseThemeConf(confstr, colscheme);
+			if (result) {
+				col_bg 						= colscheme[0] | BIT(15);
+				col_dark_bg 				= colscheme[1] | BIT(15);
+				col_medium_bg 				= colscheme[2] | BIT(15);
+				col_light_bg 				= colscheme[3] | BIT(15);
+				col_lighter_bg 				= colscheme[4] | BIT(15);
+				col_light_ctrl 				= colscheme[5] | BIT(15);
+				col_dark_ctrl 				= colscheme[6] | BIT(15);
+				col_light_ctrl_disabled 	= colscheme[7] | BIT(15);
+				col_dark_ctrl_disabled 		= colscheme[8] | BIT(15);
+				col_list_highlight1 		= colscheme[9] | BIT(15);
+				col_list_highlight2 		= colscheme[10] | BIT(15);
+				col_outline 				= colscheme[11] | BIT(15);
+				col_tab_outline 			= colscheme[12] | BIT(15);
+				col_sepline 				= colscheme[13] | BIT(15);
+				col_icon 					= colscheme[14] | BIT(15);
+				col_text 					= colscheme[15] | BIT(15);
+				col_signal 					= colscheme[16] | BIT(15);
+				col_signal_off 				= colscheme[17] | BIT(15);
+				col_piano_label 			= colscheme[18];
+				col_piano_label_inv 		= colscheme[19];
+				col_loop 					= colscheme[20] | BIT(15);
+				col_env_sustain 			= colscheme[21] | BIT(15);
+				col_mem_ok 					= colscheme[22] | BIT(15);
+				col_mem_warn 				= colscheme[23] | BIT(15);
+				col_mem_alert 				= colscheme[24] | BIT(15);
+				col_typewriter_cursor 		= colscheme[25] | BIT(15);
+				col_pv_lines 				= colscheme[26] | BIT(15);
+				col_pv_sublines 			= colscheme[27] | BIT(15);
+				col_pv_lines_record 		= colscheme[28] | BIT(15);
+				col_pv_cb_col1 				= colscheme[29] | BIT(15);
+				col_pv_cb_col2 				= colscheme[30] | BIT(15);
+				col_pv_cb_col1_highlight 	= colscheme[31] | BIT(15);
+				col_pv_cb_col2_highlight 	= colscheme[32] | BIT(15);
+				col_pv_left_numbers 		= colscheme[33] | BIT(15);
+				col_pv_notes 				= colscheme[34] | BIT(15);
+				col_pv_instr 				= colscheme[35] | BIT(15);
+				col_pv_volume 				= colscheme[36] | BIT(15);
+				col_pv_effect 				= colscheme[37] | BIT(15);
+				col_pv_effect_param 		= colscheme[38] | BIT(15);
+				col_pv_notes_dark 			= colscheme[39] | BIT(15);
+				col_pv_instr_dark 			= colscheme[40] | BIT(15);
+				col_pv_volume_dark 			= colscheme[41] | BIT(15);
+				col_pv_effect_dark 			= colscheme[42] | BIT(15);
+				col_pv_effect_param_dark 	= colscheme[43] | BIT(15);
+				col_pv_cb_sel_highlight 	= colscheme[44] | BIT(15);
+
+				debugprintf("loaded theme '%s'\n", themepath);
+			}
+
+			else
+				debugprintf("failed to parse theme at %s, using default\n", themepath);
+
+			free(colscheme);
+			free(confstr);
+		} else
+			debugprintf("no theme found at %s, using default\n", themepath);
+	}
+}
+
+/* ===================== PRIVATE ===================== */
+
+
+bool Theme::stringToRGB15(char* str, u16* col)
+{
+	if (str == NULL)
+		return false;
+
+	int r, g, b;
+	// can't allow '#' prepended as parser reads exactly 6 chars for each colour
+	// int res = sscanf(str, str[0] == '#' ? "#%02x%02x%02x" : "%02x%02x%02x", &r, &g, &b);
+	int res = sscanf(str, "%02x%02x%02x", &r, &g, &b);
+	if (res < 3)
+		return false;
+	*col = (u16)RGB15(r / 8, g / 8, b / 8);
+	return true;
+}
+
+// not needed as we are not writing themes currently
+// void Theme::RGB15ToString(u16 col, char* str)
+// {
+// 	sprintf(str, "%02x%02x%02x", (col & 0x1f) * 8, ((col >> 5) & 0x1f) * 8, (col >> 10) & 0x1f * 8);
+// }
+
+
+bool Theme::parseThemeConf(char* str, u16* theme_cols) {
+	if (str == NULL || theme_cols == NULL)
+		return false;
+		
+	char* valstart = str;
+	size_t rem = strlen(str);
+	char* valend = str + rem;
+	char* nextline = 0;
+	for (int i = 0; i < NUM_COLORS; i++) {
+		if (rem < 6)
+			return false;
+		size_t valsize = 0;
+		nextline = strchr(valstart, '\n');
+		valsize = nextline == NULL ?
+			valend - valstart : nextline - valstart;
+		if (valsize >= 6) {
+			char val[7];
+			strncpy(val, valstart, 6);
+			val[6] = 0;
+			u16 c;
+			bool result = stringToRGB15(val, &c);
+			if (!result)
+				return false;
+
+			theme_cols[i] = c;
+		}
+		else
+			return false;
+
+		if (nextline != NULL) {
+			rem -= valsize + 1;
+			valstart = nextline + 1;
+		}
+		else
+			break;
+	}
+
+	return true; // parsed exactly NUM_COLORS successfully
 }

--- a/tobkit/source/theme.cpp
+++ b/tobkit/source/theme.cpp
@@ -23,7 +23,7 @@ using namespace tobkit;
 Theme::Theme(char* themepath, bool use_fat) : 
 	// Set default colors
 	col_bg(RGB15(4, 6, 15) | BIT(15)),
-	col_dark_bg(col_bg),
+	col_env_bg(col_bg),
 	col_medium_bg(RGB15(9, 11, 17) | BIT(15)),
 	col_light_bg(RGB15(16, 18, 24) | BIT(15)),
 	col_lighter_bg(RGB15(23, 25, 31) | BIT(15)),
@@ -31,17 +31,28 @@ Theme::Theme(char* themepath, bool use_fat) :
 	col_dark_ctrl(RGB15(31, 18, 0) | BIT(15)),
 	col_light_ctrl_disabled(col_light_bg),
 	col_dark_ctrl_disabled(col_medium_bg),
+	col_selected_tab(col_light_bg),
+	col_unselected_tab(col_medium_bg),
 	col_list_1(col_medium_bg),
 	col_list_2(col_light_bg),
 	col_list_highlight1(RGB15(28, 15, 0) | BIT(15)),
 	col_list_highlight2(RGB15(28, 28, 0) | BIT(15)),
+	col_scrollbar_bg1(col_medium_bg),
+	col_scrollbar_bg2(col_light_bg),
+	col_scrollbar_inactive(col_dark_ctrl),
+	col_scrollbar_active(col_light_ctrl),
+	col_scrollbar_arr_bg1(col_dark_ctrl),
+	col_scrollbar_arr_bg2(col_light_ctrl),
 	col_outline(RGB15(0, 0, 0) | BIT(15)),
 	col_tab_outline(col_outline),
 	col_sepline(RGB15(31, 31, 0) | BIT(15)),
 	col_icon(RGB15(0, 0, 0) | BIT(15)),
+	col_icon_bt(col_icon),
+	col_checkmark(col_icon),
 	col_text(RGB15(0, 0, 0) | BIT(15)),
+	col_text_light(col_light_bg),
 	col_text_bt(col_text),
-	col_text_2(col_text),
+	col_text_value(col_text),
 	col_text_lb(col_text),
 	col_text_lb_highlight(col_text),
 	col_signal(RGB15(31, 0, 0) | BIT(15)),
@@ -50,11 +61,20 @@ Theme::Theme(char* themepath, bool use_fat) :
 	col_piano_label_inv(RGB15(31, 31, 31)),
 	col_loop(RGB15(7, 25, 5) | BIT(15)),
 	col_env_sustain(RGB15(0, 31, 0) | BIT(15)),
+	col_env_line(col_dark_ctrl),
+	col_env_pt(col_light_ctrl),
+	col_env_pt_border(col_outline),
+	col_env_pt_border_active(col_signal),
 	col_mem_ok(RGB15(17, 24, 16) | BIT(15)),
 	col_mem_warn(RGB15(31, 31, 0) | BIT(15)),
 	col_mem_alert(RGB15(31, 0, 0) | BIT(15)),
 	col_typewriter_cursor(RGB15(0, 0, 0) | BIT(15)),
+	col_smp_bg(col_bg),
+	col_smp_bg_sel(col_light_ctrl),
+	col_smp_waveform(RGB15(31, 19, 0) | BIT(15)),
+	col_smp_waveform_sel(RGB15(0, 0, 0) | BIT(15)),
 	col_pv_bg(col_bg),
+	col_pv_chn(col_light_bg),
 	col_pv_lines(col_light_bg),
 	col_pv_sublines(RGB15(7, 9, 17) | BIT(15)),
 	col_pv_lines_record(col_dark_ctrl),
@@ -73,12 +93,21 @@ Theme::Theme(char* themepath, bool use_fat) :
 	col_pv_effect_dark(RGB15(12, 6, 18) | BIT(15)),
 	col_pv_effect_param(RGB15(30, 26, 8) | BIT(15)),
 	col_pv_effect_param_dark(RGB15(9, 8, 5) | BIT(15)),
-	col_pv_cb_sel_highlight(RGB15(31, 24, 0) | BIT(15)), fat(use_fat)
+	col_pv_cb_sel_highlight(RGB15(31, 24, 0) | BIT(15)), 
+	col_pv_pb(col_outline),
+	col_pv_pb_cell(col_outline),
+	col_pv_mutesolo_text(col_text),
+	col_pv_mutesolo_col1(col_pv_cb_col1),
+	col_pv_mutesolo_col2(col_pv_cb_col2),
+	col_pv_mutesolo_col1_highlight(col_pv_cb_col1_highlight),
+	col_pv_mutesolo_col2_highlight(col_pv_cb_col2_highlight),
+	
+	fat(use_fat)
 {
 	if (fat == true && themepath != NULL)
 	{
 		FILE* themedef = fopen(themepath, "r");
-		debugprintf("loading theme '%s'\n", themepath);
+		// debugprintf("loading theme '%s'\n", themepath);
 
 		if (themedef != NULL)  {
 			u16* colscheme = (u16*)calloc(NUM_COLORS, sizeof(u16));
@@ -87,58 +116,85 @@ Theme::Theme(char* themepath, bool use_fat) :
 			fclose(themedef);
 
 			if (result) {
-				col_bg 						= colscheme[0] | BIT(15);
-				col_dark_bg 				= colscheme[1] | BIT(15);
-				col_medium_bg 				= colscheme[2] | BIT(15);
-				col_light_bg 				= colscheme[3] | BIT(15);
-				col_lighter_bg 				= colscheme[4] | BIT(15);
-				col_light_ctrl 				= colscheme[5] | BIT(15);
-				col_dark_ctrl 				= colscheme[6] | BIT(15);
-				col_light_ctrl_disabled 	= colscheme[7] | BIT(15);
-				col_dark_ctrl_disabled 		= colscheme[8] | BIT(15);
-				col_list_1					= colscheme[9] | BIT(15);
-				col_list_2					= colscheme[10] | BIT(15);
-				col_list_highlight1 		= colscheme[11] | BIT(15);
-				col_list_highlight2 		= colscheme[12] | BIT(15);
-				col_outline 				= colscheme[13] | BIT(15);
-				col_tab_outline 			= colscheme[14] | BIT(15);
-				col_sepline 				= colscheme[15] | BIT(15);
-				col_icon 					= colscheme[16] | BIT(15);
-				col_text 					= colscheme[17] | BIT(15);
-				col_text_bt 				= colscheme[18] | BIT(15);
-				col_text_lb 				= colscheme[19] | BIT(15);
-				col_text_2 					= colscheme[20] | BIT(15);
-				col_text_lb_highlight 		= colscheme[21] | BIT(15);
-				col_signal 					= colscheme[22] | BIT(15);
-				col_signal_off 				= colscheme[23] | BIT(15);
-				col_piano_label 			= colscheme[24];
-				col_piano_label_inv 		= colscheme[25];
-				col_loop 					= colscheme[26] | BIT(15);
-				col_env_sustain 			= colscheme[27] | BIT(15);
-				col_mem_ok 					= colscheme[28] | BIT(15);
-				col_mem_warn 				= colscheme[29] | BIT(15);
-				col_mem_alert 				= colscheme[30] | BIT(15);
-				col_typewriter_cursor 		= colscheme[31] | BIT(15);
-				col_pv_bg					= colscheme[32] | BIT(15);
-				col_pv_lines 				= colscheme[33] | BIT(15);
-				col_pv_sublines 			= colscheme[34] | BIT(15);
-				col_pv_lines_record 		= colscheme[35] | BIT(15);
-				col_pv_cb_col1 				= colscheme[36] | BIT(15);
-				col_pv_cb_col2 				= colscheme[37] | BIT(15);
-				col_pv_cb_col1_highlight 	= colscheme[38] | BIT(15);
-				col_pv_cb_col2_highlight 	= colscheme[39] | BIT(15);
-				col_pv_left_numbers 		= colscheme[40] | BIT(15);
-				col_pv_notes 				= colscheme[41] | BIT(15);
-				col_pv_notes_dark 			= colscheme[42] | BIT(15);
-				col_pv_instr 				= colscheme[43] | BIT(15);
-				col_pv_instr_dark 			= colscheme[44] | BIT(15);
-				col_pv_volume 				= colscheme[45] | BIT(15);
-				col_pv_volume_dark 			= colscheme[46] | BIT(15);
-				col_pv_effect 				= colscheme[47] | BIT(15);
-				col_pv_effect_dark 			= colscheme[48] | BIT(15);
-				col_pv_effect_param 		= colscheme[49] | BIT(15);
-				col_pv_effect_param_dark 	= colscheme[50] | BIT(15);
-				col_pv_cb_sel_highlight 	= colscheme[51] | BIT(15);
+				col_bg							= colscheme[0] | BIT(15);
+				col_env_bg 						= colscheme[1] | BIT(15);
+				col_medium_bg 					= colscheme[2] | BIT(15);
+				col_light_bg 					= colscheme[3] | BIT(15);
+				col_lighter_bg 					= colscheme[4] | BIT(15);
+				col_light_ctrl 					= colscheme[5] | BIT(15);
+				col_dark_ctrl 					= colscheme[6] | BIT(15);
+				col_light_ctrl_disabled 		= colscheme[7] | BIT(15);
+				col_dark_ctrl_disabled 			= colscheme[8] | BIT(15);
+				col_selected_tab 				= colscheme[9] | BIT(15);
+				col_unselected_tab 				= colscheme[10] | BIT(15);
+				col_list_1 						= colscheme[11] | BIT(15);
+				col_list_2 						= colscheme[12] | BIT(15);
+				col_list_highlight1 			= colscheme[13] | BIT(15);
+				col_list_highlight2 			= colscheme[14] | BIT(15);
+				col_scrollbar_bg1 				= colscheme[15] | BIT(15);
+				col_scrollbar_bg2 				= colscheme[16] | BIT(15);
+				col_scrollbar_inactive 			= colscheme[17] | BIT(15);
+				col_scrollbar_active 			= colscheme[18] | BIT(15);
+				col_scrollbar_arr_bg1 			= colscheme[19] | BIT(15);
+				col_scrollbar_arr_bg2 			= colscheme[20] | BIT(15);
+				col_outline 					= colscheme[21] | BIT(15);
+				col_tab_outline 				= colscheme[22] | BIT(15);
+				col_sepline 					= colscheme[23] | BIT(15);
+				col_icon 						= colscheme[24] | BIT(15);
+				col_icon_bt 					= colscheme[25] | BIT(15);
+				col_checkmark 					= colscheme[26] | BIT(15);
+				col_text 						= colscheme[27] | BIT(15);
+				col_text_light 					= colscheme[28] | BIT(15);
+				col_text_bt 					= colscheme[29] | BIT(15);
+				col_text_value 					= colscheme[30] | BIT(15);
+				col_text_lb 					= colscheme[31] | BIT(15);
+				col_text_lb_highlight 			= colscheme[32] | BIT(15);
+				col_signal 						= colscheme[33] | BIT(15);
+				col_signal_off 					= colscheme[34] | BIT(15);
+				col_piano_label 				= colscheme[35];
+				col_piano_label_inv 			= colscheme[36];
+				col_loop 						= colscheme[37] | BIT(15);
+				col_env_sustain 				= colscheme[38] | BIT(15);
+				col_env_line 					= colscheme[39] | BIT(15);
+				col_env_pt 						= colscheme[40] | BIT(15);
+				col_env_pt_border 				= colscheme[41] | BIT(15);
+				col_env_pt_border_active 		= colscheme[42] | BIT(15);
+				col_mem_ok 						= colscheme[43] | BIT(15);
+				col_mem_warn 					= colscheme[44] | BIT(15);
+				col_mem_alert 					= colscheme[45] | BIT(15);
+				col_typewriter_cursor 			= colscheme[46] | BIT(15);
+				col_smp_bg 						= colscheme[47] | BIT(15);
+				col_smp_bg_sel 					= colscheme[48] | BIT(15);
+				col_smp_waveform 				= colscheme[49] | BIT(15);
+				col_smp_waveform_sel 			= colscheme[50] | BIT(15);
+				col_pv_bg 						= colscheme[51] | BIT(15);
+				col_pv_chn 						= colscheme[52] | BIT(15);
+				col_pv_lines 					= colscheme[53] | BIT(15);
+				col_pv_sublines 				= colscheme[54] | BIT(15);
+				col_pv_lines_record 			= colscheme[55] | BIT(15);
+				col_pv_cb_col1 					= colscheme[56] | BIT(15);
+				col_pv_cb_col2 					= colscheme[57] | BIT(15);
+				col_pv_cb_col1_highlight 		= colscheme[58] | BIT(15);
+				col_pv_cb_col2_highlight 		= colscheme[59] | BIT(15);
+				col_pv_left_numbers 			= colscheme[60] | BIT(15);
+				col_pv_notes 					= colscheme[61] | BIT(15);
+				col_pv_notes_dark 				= colscheme[62] | BIT(15);
+				col_pv_instr 					= colscheme[63] | BIT(15);
+				col_pv_instr_dark 				= colscheme[64] | BIT(15);
+				col_pv_volume 					= colscheme[65] | BIT(15);
+				col_pv_volume_dark 				= colscheme[66] | BIT(15);
+				col_pv_effect 					= colscheme[67] | BIT(15);
+				col_pv_effect_dark 				= colscheme[68] | BIT(15);
+				col_pv_effect_param 			= colscheme[69] | BIT(15);
+				col_pv_effect_param_dark 		= colscheme[70] | BIT(15);
+				col_pv_cb_sel_highlight 		= colscheme[71] | BIT(15);
+				col_pv_pb 						= colscheme[72] | BIT(15);
+				col_pv_pb_cell					= colscheme[73] | BIT(15);
+				col_pv_mutesolo_text 			= colscheme[74] | BIT(15);
+				col_pv_mutesolo_col1 			= colscheme[75] | BIT(15);
+				col_pv_mutesolo_col2 			= colscheme[76] | BIT(15);
+				col_pv_mutesolo_col1_highlight 	= colscheme[77] | BIT(15);
+				col_pv_mutesolo_col2_highlight 	= colscheme[78] | BIT(15);
 
 				debugprintf("loaded theme '%s'\n", themepath);
 			}
@@ -176,25 +232,32 @@ void Theme::RGB15ToString(u16 col, char* str)
 	sprintf(str, "%02x%02x%02x", (col & 0x1f) * 255 / 31, ((col >> 5) & 0x1f) * 255 / 31, (col >> 10 & 0x1f) * 255 / 31);
 }
 
+
 bool Theme::parseTheme(FILE *theme_, u16 *theme_cols) {
 	if (theme_ == NULL || theme_cols == NULL)
 		return false;
 
 	int theme_i = 0;
-	int r, g, b;
-	int parsed = 0;
+	int r, g, b, k, parsed;
+
 	for (int l = 0; l < NUM_COLORS; ++l) {
-		parsed = fscanf(theme_, "%02x%02x%02x%*[^\n]\n", &r, &g, &b);
-		if (parsed != 3) {
-			debugprintf("theme parse error on line %d, aborting\n", l);
+		parsed = fscanf(theme_, "%d=%02x%02x%02x%*[^\n]\n", &k, &r, &g, &b);
+		
+		if (parsed != 4 || k < 0) {
+			debugprintf("theme parse error on line %d\n", l + 1);
+			return false;
+		} else if ( k > NUM_COLORS - 1 ) {
+			debugprintf("theme parse error on line %d (key out of bounds, max %d)  \n", l + 1, NUM_COLORS - 1);
 			return false;
 		}
-			
-		theme_cols[theme_i++] = RGB15(r * 31 / 255, g * 31 / 255, b * 31 / 255);
+		theme_cols[k] = RGB15(r * 31 / 255, g * 31 / 255, b * 31 / 255);
+		theme_i++;
 	} 
 
-	if (theme_i < NUM_COLORS)
+	if (theme_i < NUM_COLORS - 1) {
+		debugprintf("theme only specifies %u colors, need %u\n", theme_i, NUM_COLORS);
 		return false;
+	}
+		
 	return true;
 }
-

--- a/tobkit/source/theme.cpp
+++ b/tobkit/source/theme.cpp
@@ -31,6 +31,8 @@ Theme::Theme(char* themepath, bool use_fat) :
 	col_dark_ctrl(RGB15(31, 18, 0) | BIT(15)),
 	col_light_ctrl_disabled(col_light_bg),
 	col_dark_ctrl_disabled(col_medium_bg),
+	col_list_1(col_medium_bg),
+	col_list_2(col_light_bg),
 	col_list_highlight1(RGB15(28, 15, 0) | BIT(15)),
 	col_list_highlight2(RGB15(28, 28, 0) | BIT(15)),
 	col_outline(RGB15(0, 0, 0) | BIT(15)),
@@ -38,6 +40,10 @@ Theme::Theme(char* themepath, bool use_fat) :
 	col_sepline(RGB15(31, 31, 0) | BIT(15)),
 	col_icon(RGB15(0, 0, 0) | BIT(15)),
 	col_text(RGB15(0, 0, 0) | BIT(15)),
+	col_text_bt(col_text),
+	col_text_2(col_text),
+	col_text_lb(col_text),
+	col_text_lb_highlight(col_text),
 	col_signal(RGB15(31, 0, 0) | BIT(15)),
 	col_signal_off(RGB15(18, 0, 0) | BIT(15)),
 	col_piano_label(RGB15(0, 0, 0)),
@@ -48,6 +54,7 @@ Theme::Theme(char* themepath, bool use_fat) :
 	col_mem_warn(RGB15(31, 31, 0) | BIT(15)),
 	col_mem_alert(RGB15(31, 0, 0) | BIT(15)),
 	col_typewriter_cursor(RGB15(0, 0, 0) | BIT(15)),
+	col_pv_bg(col_bg),
 	col_pv_lines(col_light_bg),
 	col_pv_sublines(RGB15(7, 9, 17) | BIT(15)),
 	col_pv_lines_record(col_dark_ctrl),
@@ -70,20 +77,15 @@ Theme::Theme(char* themepath, bool use_fat) :
 {
 	if (fat == true && themepath != NULL)
 	{
-		FILE* conf = fopen(themepath, "r");
+		FILE* themedef = fopen(themepath, "r");
 		debugprintf("loading theme '%s'\n", themepath);
 
-		if (conf != NULL)  {
-			fseek(conf, 0, SEEK_END);
-			u32 conf_filesize = ftell(conf);
-			fseek(conf, 0, SEEK_SET);
-
-			char* confstr = (char*)calloc(1, conf_filesize);
-			fread(confstr, conf_filesize, 1, conf);
-			fclose(conf);
-
+		if (themedef != NULL)  {
 			u16* colscheme = (u16*)calloc(NUM_COLORS, sizeof(u16));
-			bool result = parseThemeConf(confstr, colscheme);
+			bool result = parseTheme(themedef, colscheme);
+
+			fclose(themedef);
+
 			if (result) {
 				col_bg 						= colscheme[0] | BIT(15);
 				col_dark_bg 				= colscheme[1] | BIT(15);
@@ -94,53 +96,59 @@ Theme::Theme(char* themepath, bool use_fat) :
 				col_dark_ctrl 				= colscheme[6] | BIT(15);
 				col_light_ctrl_disabled 	= colscheme[7] | BIT(15);
 				col_dark_ctrl_disabled 		= colscheme[8] | BIT(15);
-				col_list_highlight1 		= colscheme[9] | BIT(15);
-				col_list_highlight2 		= colscheme[10] | BIT(15);
-				col_outline 				= colscheme[11] | BIT(15);
-				col_tab_outline 			= colscheme[12] | BIT(15);
-				col_sepline 				= colscheme[13] | BIT(15);
-				col_icon 					= colscheme[14] | BIT(15);
-				col_text 					= colscheme[15] | BIT(15);
-				col_signal 					= colscheme[16] | BIT(15);
-				col_signal_off 				= colscheme[17] | BIT(15);
-				col_piano_label 			= colscheme[18];
-				col_piano_label_inv 		= colscheme[19];
-				col_loop 					= colscheme[20] | BIT(15);
-				col_env_sustain 			= colscheme[21] | BIT(15);
-				col_mem_ok 					= colscheme[22] | BIT(15);
-				col_mem_warn 				= colscheme[23] | BIT(15);
-				col_mem_alert 				= colscheme[24] | BIT(15);
-				col_typewriter_cursor 		= colscheme[25] | BIT(15);
-				col_pv_lines 				= colscheme[26] | BIT(15);
-				col_pv_sublines 			= colscheme[27] | BIT(15);
-				col_pv_lines_record 		= colscheme[28] | BIT(15);
-				col_pv_cb_col1 				= colscheme[29] | BIT(15);
-				col_pv_cb_col2 				= colscheme[30] | BIT(15);
-				col_pv_cb_col1_highlight 	= colscheme[31] | BIT(15);
-				col_pv_cb_col2_highlight 	= colscheme[32] | BIT(15);
-				col_pv_left_numbers 		= colscheme[33] | BIT(15);
-				col_pv_notes 				= colscheme[34] | BIT(15);
-				col_pv_instr 				= colscheme[35] | BIT(15);
-				col_pv_volume 				= colscheme[36] | BIT(15);
-				col_pv_effect 				= colscheme[37] | BIT(15);
-				col_pv_effect_param 		= colscheme[38] | BIT(15);
-				col_pv_notes_dark 			= colscheme[39] | BIT(15);
-				col_pv_instr_dark 			= colscheme[40] | BIT(15);
-				col_pv_volume_dark 			= colscheme[41] | BIT(15);
-				col_pv_effect_dark 			= colscheme[42] | BIT(15);
-				col_pv_effect_param_dark 	= colscheme[43] | BIT(15);
-				col_pv_cb_sel_highlight 	= colscheme[44] | BIT(15);
+				col_list_1					= colscheme[9] | BIT(15);
+				col_list_2					= colscheme[10] | BIT(15);
+				col_list_highlight1 		= colscheme[11] | BIT(15);
+				col_list_highlight2 		= colscheme[12] | BIT(15);
+				col_outline 				= colscheme[13] | BIT(15);
+				col_tab_outline 			= colscheme[14] | BIT(15);
+				col_sepline 				= colscheme[15] | BIT(15);
+				col_icon 					= colscheme[16] | BIT(15);
+				col_text 					= colscheme[17] | BIT(15);
+				col_text_bt 				= colscheme[18] | BIT(15);
+				col_text_lb 				= colscheme[19] | BIT(15);
+				col_text_2 					= colscheme[20] | BIT(15);
+				col_text_lb_highlight 		= colscheme[21] | BIT(15);
+				col_signal 					= colscheme[22] | BIT(15);
+				col_signal_off 				= colscheme[23] | BIT(15);
+				col_piano_label 			= colscheme[24];
+				col_piano_label_inv 		= colscheme[25];
+				col_loop 					= colscheme[26] | BIT(15);
+				col_env_sustain 			= colscheme[27] | BIT(15);
+				col_mem_ok 					= colscheme[28] | BIT(15);
+				col_mem_warn 				= colscheme[29] | BIT(15);
+				col_mem_alert 				= colscheme[30] | BIT(15);
+				col_typewriter_cursor 		= colscheme[31] | BIT(15);
+				col_pv_bg					= colscheme[32] | BIT(15);
+				col_pv_lines 				= colscheme[33] | BIT(15);
+				col_pv_sublines 			= colscheme[34] | BIT(15);
+				col_pv_lines_record 		= colscheme[35] | BIT(15);
+				col_pv_cb_col1 				= colscheme[36] | BIT(15);
+				col_pv_cb_col2 				= colscheme[37] | BIT(15);
+				col_pv_cb_col1_highlight 	= colscheme[38] | BIT(15);
+				col_pv_cb_col2_highlight 	= colscheme[39] | BIT(15);
+				col_pv_left_numbers 		= colscheme[40] | BIT(15);
+				col_pv_notes 				= colscheme[41] | BIT(15);
+				col_pv_notes_dark 			= colscheme[42] | BIT(15);
+				col_pv_instr 				= colscheme[43] | BIT(15);
+				col_pv_instr_dark 			= colscheme[44] | BIT(15);
+				col_pv_volume 				= colscheme[45] | BIT(15);
+				col_pv_volume_dark 			= colscheme[46] | BIT(15);
+				col_pv_effect 				= colscheme[47] | BIT(15);
+				col_pv_effect_dark 			= colscheme[48] | BIT(15);
+				col_pv_effect_param 		= colscheme[49] | BIT(15);
+				col_pv_effect_param_dark 	= colscheme[50] | BIT(15);
+				col_pv_cb_sel_highlight 	= colscheme[51] | BIT(15);
 
 				debugprintf("loaded theme '%s'\n", themepath);
 			}
 
 			else
-				debugprintf("failed to parse theme at %s, using default\n", themepath);
+				debugprintf("failed to parse theme at '%s', using builtin\n", themepath);
 
 			free(colscheme);
-			free(confstr);
 		} else
-			debugprintf("no theme found at %s, using default\n", themepath);
+			debugprintf("no theme found at '%s', using builtin\n", themepath);
 	}
 }
 
@@ -158,53 +166,35 @@ bool Theme::stringToRGB15(char* str, u16* col)
 	int res = sscanf(str, "%02x%02x%02x", &r, &g, &b);
 	if (res < 3)
 		return false;
-	*col = (u16)RGB15(r / 8, g / 8, b / 8);
+	*col = (u16)RGB15(r * 31 / 255, g * 31 / 255, b * 31 / 255);
 	return true;
 }
 
 // not needed as we are not writing themes currently
-// void Theme::RGB15ToString(u16 col, char* str)
-// {
-// 	sprintf(str, "%02x%02x%02x", (col & 0x1f) * 8, ((col >> 5) & 0x1f) * 8, (col >> 10) & 0x1f * 8);
-// }
-
-
-bool Theme::parseThemeConf(char* str, u16* theme_cols) {
-	if (str == NULL || theme_cols == NULL)
-		return false;
-		
-	char* valstart = str;
-	size_t rem = strlen(str);
-	char* valend = str + rem;
-	char* nextline = 0;
-	for (int i = 0; i < NUM_COLORS; i++) {
-		if (rem < 6)
-			return false;
-		size_t valsize = 0;
-		nextline = strchr(valstart, '\n');
-		valsize = nextline == NULL ?
-			valend - valstart : nextline - valstart;
-		if (valsize >= 6) {
-			char val[7];
-			strncpy(val, valstart, 6);
-			val[6] = 0;
-			u16 c;
-			bool result = stringToRGB15(val, &c);
-			if (!result)
-				return false;
-
-			theme_cols[i] = c;
-		}
-		else
-			return false;
-
-		if (nextline != NULL) {
-			rem -= valsize + 1;
-			valstart = nextline + 1;
-		}
-		else
-			break;
-	}
-
-	return true; // parsed exactly NUM_COLORS successfully
+void Theme::RGB15ToString(u16 col, char* str)
+{
+	sprintf(str, "%02x%02x%02x", (col & 0x1f) * 255 / 31, ((col >> 5) & 0x1f) * 255 / 31, (col >> 10 & 0x1f) * 255 / 31);
 }
+
+bool Theme::parseTheme(FILE *theme_, u16 *theme_cols) {
+	if (theme_ == NULL || theme_cols == NULL)
+		return false;
+
+	int theme_i = 0;
+	int r, g, b;
+	int parsed = 0;
+	for (int l = 0; l < NUM_COLORS; ++l) {
+		parsed = fscanf(theme_, "%02x%02x%02x%*[^\n]\n", &r, &g, &b);
+		if (parsed != 3) {
+			debugprintf("theme parse error on line %d, aborting\n", l);
+			return false;
+		}
+			
+		theme_cols[theme_i++] = RGB15(r * 31 / 255, g * 31 / 255, b * 31 / 255);
+	} 
+
+	if (theme_i < NUM_COLORS)
+		return false;
+	return true;
+}
+

--- a/tobkit/source/theme.cpp
+++ b/tobkit/source/theme.cpp
@@ -101,7 +101,12 @@ Theme::Theme(char* themepath, bool use_fat) :
 	col_pv_mutesolo_col2(col_pv_cb_col2),
 	col_pv_mutesolo_col1_highlight(col_pv_cb_col1_highlight),
 	col_pv_mutesolo_col2_highlight(col_pv_cb_col2_highlight),
-	
+	col_pv_left_numbers_highlight(col_pv_left_numbers),
+	col_list_sep_vertical(col_sepline),
+	col_tb_bg(col_dark_ctrl),
+	col_tb_fg_off(col_text_bt),
+	col_tb_fg_on(col_light_ctrl),
+
 	fat(use_fat)
 {
 	if (fat == true && themepath != NULL)
@@ -195,6 +200,11 @@ Theme::Theme(char* themepath, bool use_fat) :
 				col_pv_mutesolo_col2 			= colscheme[76] | BIT(15);
 				col_pv_mutesolo_col1_highlight 	= colscheme[77] | BIT(15);
 				col_pv_mutesolo_col2_highlight 	= colscheme[78] | BIT(15);
+				col_pv_left_numbers_highlight 	= colscheme[79] | BIT(15);
+				col_list_sep_vertical			= colscheme[80] | BIT(15);
+				col_tb_bg						= colscheme[81] | BIT(15);
+				col_tb_fg_off					= colscheme[82] | BIT(15);
+				col_tb_fg_on					= colscheme[83] | BIT(15);
 
 				debugprintf("loaded theme '%s'\n", themepath);
 			}

--- a/tobkit/source/togglebutton.cpp
+++ b/tobkit/source/togglebutton.cpp
@@ -115,7 +115,7 @@ void ToggleButton::draw(void)
 {
 	if(!isExposed()) return;
 
-	u16 bg = (color_bg & BIT(15)) ? color_bg : theme->col_dark_ctrl;
+	u16 bg = (color_bg & BIT(15)) ? color_bg : theme->col_tb_bg;
 	drawFullBox(1, 1, width - 2, height - 2, bg);
 	drawBorder(theme->col_outline);
 
@@ -124,13 +124,13 @@ void ToggleButton::draw(void)
 		if(on) {
 			col = bg;
 		} else {
-			col = (color_on & BIT(15)) ? color_on : theme->col_light_ctrl;
+			col = (color_on & BIT(15)) ? color_on : theme->col_tb_fg_on;
 		}
 	} else {
 		if(on) {
-			col = (color_on & BIT(15)) ? color_on : theme->col_light_ctrl;
+			col = (color_on & BIT(15)) ? color_on : theme->col_tb_fg_on;
 		} else {
-			col = (color_off & BIT(15)) ? color_off : theme->col_text_bt;
+			col = (color_off & BIT(15)) ? color_off : theme->col_tb_fg_off;
 		}
 	}
 	if(has_bitmap) {

--- a/tobkit/source/togglebutton.cpp
+++ b/tobkit/source/togglebutton.cpp
@@ -130,7 +130,7 @@ void ToggleButton::draw(void)
 		if(on) {
 			col = (color_on & BIT(15)) ? color_on : theme->col_light_ctrl;
 		} else {
-			col = (color_off & BIT(15)) ? color_off : theme->col_text;
+			col = (color_off & BIT(15)) ? color_off : theme->col_text_bt;
 		}
 	}
 	if(has_bitmap) {


### PR DESCRIPTION
edit: description is outdated 

Allow custom theme usage with a new key in NitroTracker.conf, "Theme", which accepts an unqualified file name (default 'Default.nttheme') which is read from the folder 'Themes', which is in the same directory as NitroTracker.conf.

The format of the theme files is pretty basic (rgb24 hex code without the '#' which is internally rounded to rgb15, one per line), and any data after the first six characters of a line is ignored (allowing for comments). The theme files are sensitive to order, and currently it is not possible to use empty/comment-only lines (doing so will cause the theme to fail to parse), however a newline at the end of a file is permissible (if theres any error in either opening or parsing the theme file it just uses the built-in colours)

Also added the folder 'themes' with the commented default theme for people to edit, which i added to the artifact in ci builds (the one other theme I have made I haven't fully finished so I didn't include that). Working on a proof of concept theme editor but it's unfinished atm

fixed `drawMonochromeIcon` as well which still previously defaulted to black


Hopefully this is acceptable but ofc open to change anything lol

(closed and redid the pr because the one i opened 20 mins ago had a bunch of junk commits in it lol)

closes #58

