### PR TITLE
GUI theme selector 

### DIFF
--- a/arm9/source/main.cpp
+++ b/arm9/source/main.cpp
@@ -1852,11 +1852,8 @@ void handleTranspose(s32 transpose_amount)
 void destroyThemeDialog(void)
 {
 	gui->unregisterOverlayWidget();
-	if (fbtheme) {
-		delete fbtheme;
-		fbtheme = NULL;
-	}
-		
+	delete fbtheme;
+	fbtheme = 0;
 	redrawSubScreen();
 }
 void reloadSkin(void)
@@ -1919,7 +1916,8 @@ void handleThemeReset(void)
 	destroyThemeDialog();
 	
 	settings->getTheme()->loadDefault();
-	settings->setThemeFilename("");
+	settings->setThemeFilename(" ");
+	settings->setThemePath("/");
 	settings->writeIfChanged();
 	reloadSkin();
 }

--- a/arm9/source/main.cpp
+++ b/arm9/source/main.cpp
@@ -48,7 +48,7 @@
 #include "tobkit/sampledisplay.h"
 #include "tobkit/patternview.h"
 #include "tobkit/normalizebox.h"
-
+#include "tobkit/themeselectorbox.h"
 using namespace tobkit;
 
 #include <ntxm/fifocommand.h>
@@ -208,7 +208,9 @@ GUI *gui;
 // <Settings Gui>
 	RadioButton::RadioButtonGroup *rbghandedness;
 	RadioButton *rblefthanded, *rbrighthanded;
-	GroupBox *gbhandedness, *gbdsmw;
+	Button *bttheme;
+	ThemeSelectorBox *fbtheme;
+	GroupBox *gbhandedness, *gbdsmw, *gbtheme;
 	CheckBox *cbdsmwsend, *cbdsmwrecv;
 	Button *btndsmwtoggleconnect;
 	RadioButton::RadioButtonGroup *rbgoutput;
@@ -252,6 +254,9 @@ ActionBuffer *action_buffer = NULL;
 u8 dsmw_lastnotes[16] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 u8 dsmw_lastchannels[16] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 
+char last_themepath[SETTINGS_FILENAME_LEN + 1];
+char last_themename[THEME_NAME_LEN + 1];
+
 bool fastscroll = false;
 
 uint16* map;
@@ -285,7 +290,7 @@ void clearSubScreen(void)
 	u32 colcol = col | col << 16;
 	// Fill the bg with the bg color except for the place where the keyboard is
 	dmaFillWords(colcol, sub_vram, 256 * 153 * 2);
-	for(int y=154;y<192;++y)
+	for(int y=153;y<192;++y)
 	{
 		dmaFillWords(0, sub_vram + (256*y), 224 * 2);
 		dmaFillWords(colcol, sub_vram + (256*y) + 224, (256 - 224) * 2);
@@ -1844,6 +1849,97 @@ void handleTranspose(s32 transpose_amount)
 	}
 }
 
+void destroyThemeDialog(void)
+{
+	gui->unregisterOverlayWidget();
+	if (fbtheme) {
+		delete fbtheme;
+		fbtheme = NULL;
+	}
+		
+	redrawSubScreen();
+}
+void reloadSkin(void)
+{
+	gui->setTheme(settings->getTheme(), settings->getTheme()->col_bg);
+
+	for (int y = 153; y < 192;++y)
+	{
+		// fill the quirky little square next to the piano
+		u16 col = settings->getTheme()->col_bg;
+		u32 colcol = col | col << 16;
+		dmaFillWords(colcol, sub_vram + (256 * y) + 224, (256 - 224) * 2);
+	}
+	gui->draw();
+	redrawSubScreen();
+	redraw_main_requested = true;
+}
+
+void handleThemeChosen(File file)
+{
+	if(!file.is_dir)
+	{
+		const char *str = file.name.c_str();
+		int slen = strlen(str);
+
+		if(slen > 8 && (strcasecmp(&str[slen-8], ".nttheme") == 0))
+		{
+			// if(state->playing)
+			// 	pausePlay();
+
+			settings->getTheme()->loadTheme(file.name_with_path.c_str());
+			// set theme path and name separately so the theme picker
+			// opens in the last used theme folder
+			settings->setThemePath(fbtheme->getDir().c_str());
+			settings->setThemeFilename(file.name.c_str());
+			
+			reloadSkin();
+		}
+	}
+}
+
+
+void handleThemeCancel(void)
+{
+	char last_themenamepath[SETTINGS_FILENAME_LEN + THEME_NAME_LEN + 1];
+	snprintf(last_themenamepath, SETTINGS_FILENAME_LEN + THEME_NAME_LEN + 1, "%s%s",
+	last_themepath, last_themename);
+	settings->getTheme()->loadTheme(last_themenamepath);
+	
+	// a bit messy doing it this way but it works 
+	settings->setThemePath(last_themepath);
+	settings->setThemeFilename(last_themename);
+	reloadSkin();
+
+	destroyThemeDialog();
+}
+
+void handleThemeReset(void)
+{
+	destroyThemeDialog();
+	
+	settings->getTheme()->loadDefault();
+	settings->setThemeFilename("");
+	settings->writeIfChanged();
+	reloadSkin();
+}
+
+void handleThemeApply(void)
+{
+	settings->writeIfChanged();
+	destroyThemeDialog();
+}
+void handleThemeButton(void)
+{
+	pausePlay();
+	strncpy(last_themename, settings->getThemeFilename(), THEME_NAME_LEN);
+	strncpy(last_themepath, settings->getThemePath(), SETTINGS_FILENAME_LEN);
+	fbtheme = new tobkit::ThemeSelectorBox(&sub_vram, handleThemeChosen, handleThemeApply, handleThemeReset, handleThemeCancel);
+	fbtheme->setDir(settings->getThemePath());
+	gui->registerOverlayWidget(fbtheme, 0, SUB_SCREEN);
+	fbtheme->reveal();
+}
+
 void handleTransposeUp(void)
 {
 	u16 keysheld = keysHeld();
@@ -2798,7 +2894,7 @@ void setupGUI(bool dldi_enabled)
 	kb->registerNoteCallback(handleNoteStroke);
 	kb->registerReleaseCallback(handleNoteRelease);
 
-	pixmaplogo = new GradientIcon(98, 1, 80, 17, settings->getTheme()->col_light_ctrl, settings->getTheme()->col_dark_ctrl,
+	pixmaplogo = new GradientIcon(98, 1, 80, 17,
 		(const u32*) nitrotracker_logo_raw, &sub_vram);
 	pixmaplogo->registerPushCallback(showAboutBox);
 
@@ -3198,6 +3294,9 @@ void setupGUI(bool dldi_enabled)
 		rbghandedness->setActive(1);
 		rbghandedness->registerChangeCallback(handleHandednessChange);
 
+
+
+
 #if defined(MIDI) || defined(SHOW_ALL_SETTINGS)
 		gbdsmw = new GroupBox(5, 55, 80, 54, &sub_vram);
 		gbdsmw->setText("dsmidi");
@@ -3210,7 +3309,15 @@ void setupGUI(bool dldi_enabled)
 
 		cbdsmwrecv = new CheckBox(7, 97, 40, 14, &sub_vram, true, true);
 		cbdsmwrecv->setCaption("receive");
+		gbtheme = new GroupBox(5, 114, 80, 25, &sub_vram);
+		bttheme = new Button(10, 125, 71, 14, &sub_vram);
+#else
+		gbtheme = new GroupBox(5, 54, 80, 25, &sub_vram);
+		bttheme = new Button(10, 64, 71, 14, &sub_vram);
 #endif
+		gbtheme->setText("theme");
+		bttheme->registerPushCallback(handleThemeButton);
+		bttheme->setCaption("select...");
 
 		gboutput = new GroupBox(89, 23, 40, 34, &sub_vram);
 		gboutput->setText("out");
@@ -3263,6 +3370,9 @@ void setupGUI(bool dldi_enabled)
 #endif
 		tabbox->registerWidget(btnconfigsave, 0, 4);
 		tabbox->registerWidget(gbhandedness, 0, 4);
+		tabbox->registerWidget(bttheme, 0, 4);
+
+		tabbox->registerWidget(gbtheme, 0, 4);
 		tabbox->registerWidget(rboutputmono, 0, 4);
 		tabbox->registerWidget(rboutputstereo, 0, 4);
 		tabbox->registerWidget(gboutput, 0, 4);
@@ -3308,7 +3418,6 @@ void setupGUI(bool dldi_enabled)
 	tbrecord = new ToggleButton(141, 136, 16, 16, &sub_vram);
 	tbrecord->setBitmap(icon_record_raw, 12, 12);
 	tbrecord->registerToggleCallback(setRecordMode);
-	tbrecord->setColorOff(settings->getTheme()->col_signal_off);
 
 	labeladd = new Label(182, 126, 22, 12, &sub_vram, false, true);
 	labeladd->setCaption("add");
@@ -3900,6 +4009,9 @@ int main(int argc, char **argv) {
 			}
 		}
 	}
+
+	last_themename[THEME_NAME_LEN] = '\0';
+	last_themepath[SETTINGS_FILENAME_LEN] = '\0';
 
 	state = new State();
 	

--- a/arm9/source/main.cpp
+++ b/arm9/source/main.cpp
@@ -255,7 +255,6 @@ u8 dsmw_lastnotes[16] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 u8 dsmw_lastchannels[16] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 
 char last_themepath[SETTINGS_FILENAME_LEN + 1];
-char last_themename[THEME_NAME_LEN + 1];
 
 bool fastscroll = false;
 
@@ -1881,14 +1880,8 @@ void handleThemeChosen(File file)
 
 		if(slen > 8 && (strcasecmp(&str[slen-8], ".nttheme") == 0))
 		{
-			// if(state->playing)
-			// 	pausePlay();
-
 			settings->getTheme()->loadTheme(file.name_with_path.c_str());
-			// set theme path and name separately so the theme picker
-			// opens in the last used theme folder
-			settings->setThemePath(fbtheme->getDir().c_str());
-			settings->setThemeFilename(file.name.c_str());
+			settings->setThemePath(file.name_with_path.c_str());
 			
 			reloadSkin();
 		}
@@ -1898,14 +1891,9 @@ void handleThemeChosen(File file)
 
 void handleThemeCancel(void)
 {
-	char last_themenamepath[SETTINGS_FILENAME_LEN + THEME_NAME_LEN + 1];
-	snprintf(last_themenamepath, SETTINGS_FILENAME_LEN + THEME_NAME_LEN + 1, "%s%s",
-	last_themepath, last_themename);
-	settings->getTheme()->loadTheme(last_themenamepath);
+	settings->getTheme()->loadTheme(last_themepath);
 	
-	// a bit messy doing it this way but it works 
 	settings->setThemePath(last_themepath);
-	settings->setThemeFilename(last_themename);
 	reloadSkin();
 
 	destroyThemeDialog();
@@ -1916,7 +1904,6 @@ void handleThemeReset(void)
 	destroyThemeDialog();
 	
 	settings->getTheme()->loadDefault();
-	settings->setThemeFilename(" ");
 	settings->setThemePath("/");
 	settings->writeIfChanged();
 	reloadSkin();
@@ -1930,10 +1917,10 @@ void handleThemeApply(void)
 void handleThemeButton(void)
 {
 	pausePlay();
-	strncpy(last_themename, settings->getThemeFilename(), THEME_NAME_LEN);
 	strncpy(last_themepath, settings->getThemePath(), SETTINGS_FILENAME_LEN);
 	fbtheme = new tobkit::ThemeSelectorBox(&sub_vram, handleThemeChosen, handleThemeApply, handleThemeReset, handleThemeCancel);
-	fbtheme->setDir(settings->getThemePath());
+	std::string themepath_(settings->getThemePath());
+	fbtheme->setDir(themepath_.substr(0, themepath_.find_last_of("/")));
 	gui->registerOverlayWidget(fbtheme, 0, SUB_SCREEN);
 	fbtheme->reveal();
 }
@@ -4008,7 +3995,6 @@ int main(int argc, char **argv) {
 		}
 	}
 
-	last_themename[THEME_NAME_LEN] = '\0';
 	last_themepath[SETTINGS_FILENAME_LEN] = '\0';
 
 	state = new State();

--- a/arm9/source/settings.cpp
+++ b/arm9/source/settings.cpp
@@ -40,9 +40,7 @@ fat(use_fat), changed(false)
 {
 	songpath[SETTINGS_FILENAME_LEN] = '\0';
 	samplepath[SETTINGS_FILENAME_LEN] = '\0';
-	themename[THEME_NAME_LEN] = '\0';
 	themepath[SETTINGS_FILENAME_LEN] = '\0';
-	themenamepath[SETTINGS_FILENAME_LEN + THEME_NAME_LEN] = '\0';
 
 	// might never have snprintf called
 	configpath[0] = '\0';
@@ -50,9 +48,7 @@ fat(use_fat), changed(false)
 
 	snprintf(songpath, SETTINGS_FILENAME_LEN, "%s/", launch_path != NULL ? launch_path : "");
 	snprintf(samplepath, SETTINGS_FILENAME_LEN, "%s/", launch_path != NULL ? launch_path : "");
-	snprintf(themepath, SETTINGS_FILENAME_LEN, "%s/Themes/", launch_path != NULL ? launch_path : "");
-	snprintf(themename, SETTINGS_FILENAME_LEN, "Default.nttheme");
-	snprintf(themenamepath, SETTINGS_FILENAME_LEN + THEME_NAME_LEN + 1, "%s%s", themepath, themename);
+	snprintf(themepath, SETTINGS_FILENAME_LEN, "%s/Themes/Default.nttheme", launch_path != NULL ? launch_path : "/data");
 	
 
 	if(fat == true)
@@ -105,20 +101,12 @@ fat(use_fat), changed(false)
 			lines_per_beat = strtoul(prevstring, NULL, 10);
 			if (!lines_per_beat || lines_per_beat > 64)
 				lines_per_beat = 8;
-
-			// the parser is greedy and will use the value for "Themepath" as "Theme"
-			// if it comes first, calling it "Themename" allows it to not be
-			// order-sensitive
-			getConfigValue(confstr, "Themename", themename, SETTINGS_FILENAME_LEN, NULL);
 			
 			free(confstr);
 		}
 	}
 
-	snprintf(themenamepath, SETTINGS_FILENAME_LEN + THEME_NAME_LEN + 1, "%s%s",
-				themepath,
-				themename); // will default to 'Default.nttheme' if no fat
-	theme = new tobkit::Theme(themenamepath, fat);
+	theme = new tobkit::Theme(themepath, fat);
 }
 
 Handedness Settings::getHandedness(void)
@@ -193,21 +181,8 @@ void Settings::setThemePath(const char *themepath_) {
 	changed = true;
 }
 
-void Settings::setThemeFilename(const char *themename_) {
-	strncpy(themename, themename_, THEME_NAME_LEN);
-	themename[THEME_NAME_LEN] = '\0';
-	changed = true;
-}
-
-char *Settings::getThemeFilename(void)
-{
-	return themename;
-}
 char *Settings::getThemePath(void)
 {
-    if(!dirExists(themepath)) {
-        strncpy(themepath, "/", SETTINGS_FILENAME_LEN);
-    }
 	return themepath;
 }
 
@@ -271,8 +246,8 @@ bool Settings::write(void)
 	boolToString(sample_preview, prevstring);
 	boolToString(stereo_output, stereostring);
 	boolToString(freq_47khz, freqstring);
-	fprintf(conf, "Samplepath = %s\nSongpath = %s\nThemepath = %s\nHandedness = %s\nSample Preview = %s\nStereo Output = %s\n47kHz Output = %s\nLines Per Beat = %d\nThemename = %s\n",
-			samplepath, songpath, themepath, hstring, prevstring, stereostring, freqstring, lines_per_beat, themename);
+	fprintf(conf, "Samplepath = %s\nSongpath = %s\nThemepath = %s\nHandedness = %s\nSample Preview = %s\nStereo Output = %s\n47kHz Output = %s\nLines Per Beat = %d\n",
+			samplepath, songpath, themepath, hstring, prevstring, stereostring, freqstring, lines_per_beat);
 	fclose(conf);
 	return true;
 }

--- a/arm9/source/settings.cpp
+++ b/arm9/source/settings.cpp
@@ -111,8 +111,6 @@ fat(use_fat), changed(false)
 			// order-sensitive
 			getConfigValue(confstr, "Themename", themename, SETTINGS_FILENAME_LEN, NULL);
 			
-			
-
 			free(confstr);
 		}
 	}

--- a/arm9/source/settings.h
+++ b/arm9/source/settings.h
@@ -32,7 +32,6 @@
 #include <stdlib.h>
 
 #define SETTINGS_FILENAME_LEN 255
-#define THEME_NAME_LEN 63
 
 enum Handedness {LEFT_HANDED, RIGHT_HANDED};
 
@@ -68,8 +67,6 @@ class Settings {
 		char *getThemePath(void);
 		void setThemePath(const char* themepath_);
 
-		char *getThemeFilename(void);
-		void setThemeFilename(const char* themefname_);
 		bool writeIfChanged(void);
 
 	private:
@@ -92,10 +89,8 @@ class Settings {
 		char configpath[SETTINGS_FILENAME_LEN + 1];
 		char songpath[SETTINGS_FILENAME_LEN + 1];
 		char samplepath[SETTINGS_FILENAME_LEN + 1];
-		char themename[THEME_NAME_LEN + 1];
 		char themepath[SETTINGS_FILENAME_LEN + 1];
-		// specify theme name and path separately 
-		char themenamepath[SETTINGS_FILENAME_LEN + THEME_NAME_LEN + 1];
+
         bool fat, changed;
 };
 

--- a/arm9/source/settings.h
+++ b/arm9/source/settings.h
@@ -65,6 +65,11 @@ class Settings {
 		char *getSamplePath(void);
 		void setSamplePath(const char* samplepath_);
 
+		char *getThemePath(void);
+		void setThemePath(const char* themepath_);
+
+		char *getThemeFilename(void);
+		void setThemeFilename(const char* themefname_);
 		bool writeIfChanged(void);
 
 	private:
@@ -89,6 +94,8 @@ class Settings {
 		char samplepath[SETTINGS_FILENAME_LEN + 1];
 		char themename[THEME_NAME_LEN + 1];
 		char themepath[SETTINGS_FILENAME_LEN + 1];
+		// specify theme name and path separately 
+		char themenamepath[SETTINGS_FILENAME_LEN + THEME_NAME_LEN + 1];
         bool fat, changed;
 };
 

--- a/tobkit/include/tobkit/gradienticon.h
+++ b/tobkit/include/tobkit/gradienticon.h
@@ -26,7 +26,7 @@ namespace tobkit {
  */
 class GradientIcon: public Widget {
 	public:
-		GradientIcon(u8 _x, u8 _y, u8 _width, u8 _height, u16 _colorTop, u16 _colorBottom, const u32* _image, u16 **_vram, bool _visible=true);
+		GradientIcon(u8 _x, u8 _y, u8 _width, u8 _height, const u32* _image, u16 **_vram, bool _visible=true);
 	
 		~GradientIcon();
 		
@@ -44,7 +44,6 @@ class GradientIcon: public Widget {
 		
 		void (*onPush)(void);
 		const u32 *image;
-		const u16 colorTop, colorBottom;
 };
 
 };

--- a/tobkit/include/tobkit/theme.h
+++ b/tobkit/include/tobkit/theme.h
@@ -23,7 +23,6 @@ limitations under the License.
 #include <nds.h>
 
 #define NUM_COLORS 84
-#define THEME_FILENAME_LEN 255
 
 namespace tobkit {
 
@@ -125,7 +124,8 @@ class Theme : public ColorScheme {
 public:
 	Theme(char* themepath = NULL, bool use_fat = true);
 	void read(void);
-
+	bool loadTheme(const char* themefile);
+	void loadDefault(void);
 private:
 	bool stringToRGB15(char* str, u16* col);
 	void RGB15ToString(u16 col, char* str);

--- a/tobkit/include/tobkit/themeselectorbox.h
+++ b/tobkit/include/tobkit/themeselectorbox.h
@@ -1,0 +1,72 @@
+/*====================================================================
+Copyright 2006 Tobias Weyand
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+======================================================================*/
+
+#ifndef THEMESELECTORBOX_H
+#define THEMESELECTORBOX_H
+
+#include "widget.h"
+#include "gui.h"
+#include "listbox.h"
+#include "fileselector.h"
+#include "button.h"
+#include <nds.h>
+
+#include <vector>
+#include <map>
+#include <string>
+
+namespace tobkit {
+
+class ThemeSelectorBox: public Widget {
+	public:
+		ThemeSelectorBox(u16 **_vram, void (*_onSelect)(File), void (*_onOk)(void), void (*_onReset)(void), void (*_onCancel)(void));
+		~ThemeSelectorBox(void);
+
+		// Event calls
+		void penDown(u8 px, u8 py);
+		void penMove(u8 px, u8 py);
+		void penUp(u8 px, u8 py);
+	
+		// Drawing request
+		void pleaseDraw(void);
+
+		void show(void);
+		void reveal(void);
+		void setTheme(Theme *theme_, u16 bgcolor_);
+
+		void setDir(std::string dir);
+		std::string getDir(void);
+
+		FileSelector *filesel;
+
+	protected:
+		void draw(void);
+		
+		void (*onSelect)(File);
+		void (*onOk)(void);
+		void (*onReset)(void);
+		void (*onCancel)(void);
+		
+		GUI gui;
+		const char *title;
+		Button *buttonok, *buttoncancel, *buttonreset;
+	private:
+
+};
+
+};
+
+#endif

--- a/tobkit/include/tobkit/togglebutton.h
+++ b/tobkit/include/tobkit/togglebutton.h
@@ -44,10 +44,6 @@ class ToggleButton: public Widget {
 		void setState(bool _on);
 		bool getState(void);
 
-		inline void setColorOff(u16 value) { color_off = value; }
-		inline void setColorOn(u16 value) { color_on = value; }
-		inline void setColorBg(u16 value) { color_bg = value; }
-
 	private:
 		void draw(void);
 
@@ -55,7 +51,6 @@ class ToggleButton: public Widget {
 
 		char *caption;
 		const u8 *bitmap;
-		u16 color_off, color_on, color_bg;
 		bool penIsDown;
 		bool on;
 		bool has_bitmap;

--- a/tobkit/source/gradienticon.cpp
+++ b/tobkit/source/gradienticon.cpp
@@ -22,9 +22,9 @@ using namespace tobkit;
 
 /* ===================== PUBLIC ===================== */
 
-GradientIcon::GradientIcon(u8 _x, u8 _y, u8 _width, u8 _height, u16 _colorTop, u16 _colorBottom, const u32* _image, u16 **_vram, bool _visible)
+GradientIcon::GradientIcon(u8 _x, u8 _y, u8 _width, u8 _height, const u32* _image, u16 **_vram, bool _visible)
 	:Widget(_x, _y, _width, _height, _vram, _visible),
-	onPush(0), image(_image), colorTop(_colorTop), colorBottom(_colorBottom)
+	onPush(0), image(_image)
 {
 	
 }
@@ -60,7 +60,7 @@ void GradientIcon::draw(void)
 	u32 colorStep = div32((1<<12), height);
 
 	for(u32 j=0; j<height; j++) {
-		colorFg = interpolateColor(colorBottom, colorTop, colorStep * j);
+		colorFg = interpolateColor(theme->col_light_ctrl, theme->col_dark_ctrl, colorStep * j);
 		for(u32 i=0; i<width; i++, pos++) {
 			if (!(pos & 0x0F)) {
 				pixel = image[pos >> 4];

--- a/tobkit/source/themeselectorbox.cpp
+++ b/tobkit/source/themeselectorbox.cpp
@@ -1,0 +1,146 @@
+/*====================================================================
+Copyright 2006 Tobias Weyand
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+======================================================================*/
+
+#include <sys/syslimits.h>
+#include <unistd.h>
+
+#include <fat.h>
+#include <sys/types.h>
+#include <sys/dir.h>
+#include <sys/stat.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <string>
+#include <algorithm>
+
+#include "tobkit/themeselectorbox.h"
+
+
+#define THEMESELBOX_WIDTH		180
+#define THEMESELBOX_HEIGHT		128
+
+using namespace tobkit;
+
+/* ===================== PUBLIC ===================== */
+
+ThemeSelectorBox::ThemeSelectorBox(u16 **_vram, void (*_onSelect)(File), void(*_onOk)(void), void (*_onReset)(void), void (*_onCancel)(void))
+	:Widget((SCREEN_WIDTH-THEMESELBOX_WIDTH)/2, (SCREEN_HEIGHT-THEMESELBOX_HEIGHT)/3,
+		THEMESELBOX_WIDTH, THEMESELBOX_HEIGHT, _vram), onSelect(_onSelect), onOk(_onOk), onReset(_onReset), onCancel(_onCancel)
+{
+    title = "choose a theme";
+
+	buttonok = new Button(x+(THEMESELBOX_WIDTH-50)/2 - 55, y+THEMESELBOX_HEIGHT-20, 50, 14, _vram);
+	buttonok->setCaption("apply");
+	buttonok->registerPushCallback(onOk);
+
+	buttonreset = new Button(x+(THEMESELBOX_WIDTH-50)/2, y+THEMESELBOX_HEIGHT-20, 50, 14, _vram);
+	buttonreset->setCaption("reset");
+	buttonreset->registerPushCallback(onReset);
+
+	buttoncancel = new Button(x+(THEMESELBOX_WIDTH-50)/2 + 55, y+THEMESELBOX_HEIGHT-20, 50, 14, _vram);
+	buttoncancel->setCaption("cancel");
+	buttoncancel->registerPushCallback(onCancel);
+	
+	filesel = new FileSelector(x + 10, y + 25, THEMESELBOX_WIDTH-20, THEMESELBOX_HEIGHT - 50, _vram, true);
+	filesel->registerFileSelectCallback(onSelect);
+	std::vector<std::string> themefilter;
+	themefilter.push_back("nttheme");
+
+	filesel->addFilter("theme", themefilter);
+
+	gui.registerWidget(buttonok, 0);
+	gui.registerWidget(buttoncancel, 0);
+	gui.registerWidget(buttonreset, 0);
+	gui.registerWidget(filesel, 0);
+}
+
+ThemeSelectorBox::~ThemeSelectorBox(void)
+{
+	delete buttonok;
+	delete buttonreset;
+	delete buttoncancel;
+	delete filesel;
+}
+
+void ThemeSelectorBox::setDir(std::string dir)
+{
+	if (filesel)
+		filesel->setDir(dir);
+}
+
+std::string ThemeSelectorBox::getDir(void)
+{
+	return filesel->getDir();
+}
+// Event calls
+void ThemeSelectorBox::penDown(u8 px, u8 py) {
+	gui.penDown(px, py);
+}
+
+void ThemeSelectorBox::penUp(u8 px, u8 py) {
+	gui.penUp(px, py);
+}
+
+void ThemeSelectorBox::penMove(u8 px, u8 py) {
+	gui.penMove(px, py);
+}
+
+void ThemeSelectorBox::show(void)
+{
+	gui.showAll();
+	Widget::show();
+}
+
+void ThemeSelectorBox::reveal(void)
+{
+	Widget::reveal();
+	gui.revealAll();
+}
+
+void ThemeSelectorBox::setTheme(Theme *theme_, u16 bgcolor_)
+{
+	theme = theme_;
+	bgcolor=bgcolor_;
+	gui.setTheme(theme, theme->col_light_bg);
+}
+
+// Drawing request
+void ThemeSelectorBox::pleaseDraw(void)
+{
+	draw();
+}
+
+
+/* ===================== PROTECTED ===================== */
+
+void ThemeSelectorBox::draw(void)
+{
+	drawGradient(theme->col_list_highlight1, theme->col_list_highlight2, 1, 1, width - 2, 15);
+	drawHLine(1, 16, width - 2, theme->col_outline);
+	drawFullBox(1, 17, width - 2, THEMESELBOX_HEIGHT-17, theme->col_light_bg);
+	drawBorder(theme->col_outline);
+	
+	u8 titlewidth = getStringWidth(title)+5;
+	drawString(title, (THEMESELBOX_WIDTH-titlewidth)/2, 4, theme->col_text, titlewidth+5);
+	
+	gui.draw();
+}
+
+/* ===================== PRIVATE ===================== */
+
+

--- a/tobkit/source/togglebutton.cpp
+++ b/tobkit/source/togglebutton.cpp
@@ -25,7 +25,6 @@ using namespace tobkit;
 
 ToggleButton::ToggleButton(u8 _x, u8 _y, u8 _width, u8 _height, u16 **_vram, bool _visible)
 	:Widget(_x, _y, _width, _height, _vram, _visible),
-	color_off(0), color_on(0), color_bg(0),
 	penIsDown(false), on(false), has_bitmap(false)
 {
 	onToggle = 0;
@@ -115,7 +114,7 @@ void ToggleButton::draw(void)
 {
 	if(!isExposed()) return;
 
-	u16 bg = (color_bg & BIT(15)) ? color_bg : theme->col_tb_bg;
+	u16 bg = theme->col_tb_bg;
 	drawFullBox(1, 1, width - 2, height - 2, bg);
 	drawBorder(theme->col_outline);
 
@@ -124,13 +123,13 @@ void ToggleButton::draw(void)
 		if(on) {
 			col = bg;
 		} else {
-			col = (color_on & BIT(15)) ? color_on : theme->col_tb_fg_on;
+			col = theme->col_tb_fg_on;
 		}
 	} else {
 		if(on) {
-			col = (color_on & BIT(15)) ? color_on : theme->col_tb_fg_on;
+			col = theme->col_tb_fg_on;
 		} else {
-			col = (color_off & BIT(15)) ? color_off : theme->col_tb_fg_off;
+			col = has_bitmap ? theme->col_signal_off : theme->col_tb_fg_off;
 		}
 	}
 	if(has_bitmap) {


### PR DESCRIPTION
Adds a new theme selection GUI in settings (which is positioned depending on if dsmidiwifi options are present) with a new class `ThemeSelectorBox`

~~changes NitroTracker.conf such that it uses both `Themepath` and `Themename`, such that the theme selector dialogue can start in the path of the user's last theme selection for convenience. The key 'Themename' is named as such and not just 'Theme' as the parser will read the value for 'Themepath' otherwise depending on their order.~~

use `Themepath` for the full path to the theme file, with the theme selector box starting in the current theme's parent dir

modify `GradientIcon` so it uses colours from theme 

start drawing the square to the right of the piano one pixel up to get rid of the black line

modify bitmap togglebutton to use theme colour 