### PR TITLE
use storage root by default if settings has no Themepath

### DIFF
--- a/arm9/source/settings.cpp
+++ b/arm9/source/settings.cpp
@@ -48,7 +48,7 @@ fat(use_fat), changed(false)
 
 	snprintf(songpath, SETTINGS_FILENAME_LEN, "%s/", launch_path != NULL ? launch_path : "");
 	snprintf(samplepath, SETTINGS_FILENAME_LEN, "%s/", launch_path != NULL ? launch_path : "");
-	snprintf(themepath, SETTINGS_FILENAME_LEN, "%s/Themes/Default.nttheme", launch_path != NULL ? launch_path : "/data");
+	snprintf(themepath, SETTINGS_FILENAME_LEN, "%s/Default.nttheme", launch_path != NULL ? launch_path : "");
 	
 
 	if(fat == true)


### PR DESCRIPTION
i upgraded an existing installation with no Themepath key in the config and the theme chooser dialog tried to start in a nonexistent directory, so just a quick hotfix