### PR TITLE
Piano theming, also allow incomplete themes

### DIFF
--- a/themes/Default.nttheme
+++ b/themes/Default.nttheme
@@ -82,3 +82,11 @@
 76=8394c5 ; Pattern - mute/solo gradient 2
 77=e67b00 ; Pattern - mute/solo gradient 1 (highlight)
 78=e6e600 ; Pattern - mute/solo gradient 2 (highlight)
+84=ffffff ; Piano - full key color 1
+85=cbcbcb ; Piano - full key color 2
+86=000000 ; Piano - half key color 1
+87=383838 ; Piano - half key color 2
+88=b2b2e3 ; Piano - full key color 1 (highlight)
+89=a2a2d3 ; Piano - full key color 2 (highlight)
+90=690000 ; Piano - half key color 1 (highlight)
+91=9a3838 ; Piano - half key color 2 (highlight)

--- a/tobkit/include/tobkit/piano.h
+++ b/tobkit/include/tobkit/piano.h
@@ -45,17 +45,20 @@ class Piano: public Widget {
 		void showKeyLabels(void);
 		void hideKeyLabels(void);
 		void setKeyLabel(u8 key, char label);
-		
+		void setTheme(Theme *theme_, u16 bgcolor_);
+
 	private:
 		void (*onNote)(u8);
 		void (*onRelease)(u8, bool);
 		uint16 *char_base, *map_base;
 		
+		unsigned short piano_Palette[16], piano_fullnotehighlight_Palette[16], piano_halfnotehighlight_Palette[16];
+		
 		void draw(void);
 		void setKeyPal(u8 note);
 		u8 isHalfTone(u8 note);
 		void resetPals(void);
-		
+		void genPal(u16 *piano_cols_base, u16 *pal, u16 *pal_full_highlight, u16 *pal_half_highlight);
 		void drawKeyLabel(u8 key, bool visible=true);
 		void eraseKeyLabel(u8 key);
 		

--- a/tobkit/include/tobkit/theme.h
+++ b/tobkit/include/tobkit/theme.h
@@ -22,7 +22,7 @@ limitations under the License.
 #include "../../arm9/source/tools.h" 
 #include <nds.h>
 
-#define NUM_COLORS 84
+#define NUM_COLORS 92
 
 namespace tobkit {
 
@@ -114,6 +114,14 @@ struct ColorScheme {
 			u16 col_tb_bg;
 			u16 col_tb_fg_off;
 			u16 col_tb_fg_on;
+			u16 col_piano_full_col1;
+			u16 col_piano_full_col2;
+			u16 col_piano_half_col1;
+			u16 col_piano_half_col2;
+			u16 col_piano_full_highlight_col1;
+			u16 col_piano_full_highlight_col2;
+			u16 col_piano_half_highlight_col1;
+			u16 col_piano_half_highlight_col2;
 		};
 	};
 

--- a/tobkit/source/piano.cpp
+++ b/tobkit/source/piano.cpp
@@ -49,10 +49,10 @@ void Piano::setTheme(Theme *theme_, u16 bgcolor_) {
 	u16 piano_cols[8] = { theme_->col_piano_full_col1, theme_->col_piano_full_col2, theme_->col_piano_half_col1, theme_->col_piano_half_col2, 
 						theme_->col_piano_full_highlight_col1, theme_->col_piano_full_highlight_col2, theme_->col_piano_half_highlight_col1, theme_->col_piano_half_highlight_col2};
 	genPal(piano_cols, piano_Palette, piano_fullnotehighlight_Palette, piano_halfnotehighlight_Palette);
-	DC_FlushAll();
-	dmaCopy(piano_Palette, BG_PALETTE_SUB, 32);
-	dmaCopy(piano_fullnotehighlight_Palette, BG_PALETTE_SUB+16, 32);
-	dmaCopy(piano_halfnotehighlight_Palette, BG_PALETTE_SUB+32, 32);
+
+	memcpy(BG_PALETTE_SUB, piano_Palette, 32);
+	memcpy(BG_PALETTE_SUB+16, piano_fullnotehighlight_Palette, 32);
+	memcpy(BG_PALETTE_SUB+32, piano_halfnotehighlight_Palette, 32);
 	pleaseDraw();
 }
 

--- a/tobkit/source/piano.cpp
+++ b/tobkit/source/piano.cpp
@@ -20,7 +20,6 @@ limitations under the License.
 #include "tobkit/piano.h"
 
 #include "piano.h"
-#include "piano_pal.h"
 #include "piano_hit.h"
 
 using namespace tobkit;
@@ -30,6 +29,8 @@ using namespace tobkit;
 static u8 halftones[] = {1, 3, 6, 8, 10, 13, 15, 18, 20, 22};
 static u8 x_offsets[] = {0, 11, 16, 27, 32, 48, 59, 64, 75, 80, 91, 96};
 
+
+
 /* ===================== PUBLIC ===================== */
 Piano::Piano(u8 _x, u8 _y, u8 _width, u8 _height, u16 *_char_base, u16 *_map_base, u16 **_vram)
 :Widget(_x, _y, _width, _height, _vram),
@@ -37,12 +38,22 @@ char_base(_char_base), map_base(_map_base), key_labels_visible(false)
 {
 	onNote = 0;
 	onRelease = 0;
-	dmaCopy(piano_Palette, BG_PALETTE_SUB, 32);
-	dmaCopy(piano_fullnotehighlight_Palette, BG_PALETTE_SUB+16, 32);
-	dmaCopy(piano_halfnotehighlight_Palette, BG_PALETTE_SUB+32, 32);
+
+	// Piano::draw is never invoked before Piano::setTheme
 	dmaCopy(pianoTiles, char_base, sizeof(pianoTiles));
 	
 	memset(key_labels, ' ', 24);
+}
+
+void Piano::setTheme(Theme *theme_, u16 bgcolor_) {
+	u16 piano_cols[8] = { theme_->col_piano_full_col1, theme_->col_piano_full_col2, theme_->col_piano_half_col1, theme_->col_piano_half_col2, 
+						theme_->col_piano_full_highlight_col1, theme_->col_piano_full_highlight_col2, theme_->col_piano_half_highlight_col1, theme_->col_piano_half_highlight_col2};
+	genPal(piano_cols, piano_Palette, piano_fullnotehighlight_Palette, piano_halfnotehighlight_Palette);
+	DC_FlushAll();
+	dmaCopy(piano_Palette, BG_PALETTE_SUB, 32);
+	dmaCopy(piano_fullnotehighlight_Palette, BG_PALETTE_SUB+16, 32);
+	dmaCopy(piano_halfnotehighlight_Palette, BG_PALETTE_SUB+32, 32);
+	pleaseDraw();
 }
 
 
@@ -146,6 +157,21 @@ void Piano::setKeyLabel(u8 key, char label)
 }
 
 /* ===================== PRIVATE ===================== */
+
+void Piano::genPal(u16 *piano_cols_base, u16 *pal, u16 *pal_full_highlight, u16 *pal_half_highlight) {
+	for (int i = 0; i < 9; ++i) {
+		pal[i] = interpolateColor(piano_cols_base[2], piano_cols_base[3], (4096 / 9) * i);
+		pal_half_highlight[i] = interpolateColor(piano_cols_base[6], piano_cols_base[7], (4096 / 9) * i);
+	}
+	memcpy(&pal_full_highlight[0], &pal[0], 9 * sizeof(u16));
+
+
+	for (int i = 0; i < 7; ++i) {
+		pal[i + 9] = interpolateColor(piano_cols_base[0], piano_cols_base[1], (4096 / 7) * i);
+		pal_full_highlight[i + 9] = interpolateColor(piano_cols_base[4], piano_cols_base[5], (4096 / 7) * i);
+	}
+	memcpy(&pal_half_highlight[9], &pal[9], 7 * sizeof(u16));
+}
 
 void Piano::draw(void)
 {

--- a/tobkit/source/theme.cpp
+++ b/tobkit/source/theme.cpp
@@ -105,6 +105,14 @@ ColorScheme::ColorScheme() {
 	col_tb_bg = col_dark_ctrl;
 	col_tb_fg_off = col_text_bt;
 	col_tb_fg_on = col_light_ctrl;
+	col_piano_full_col1 = RGB15(31, 31, 31) | BIT(15);
+	col_piano_full_col2 = RGB15(25, 25, 25) | BIT(15);
+	col_piano_half_col1 = RGB15(8, 8, 8) | BIT(15);
+	col_piano_half_col2 = RGB15(0, 0, 0) | BIT(15);
+	col_piano_full_highlight_col1 = RGB15(24, 24, 30) | BIT(15);
+	col_piano_full_highlight_col2 = RGB15(20, 20, 26) | BIT(15);
+	col_piano_half_highlight_col1 = RGB15(20, 8, 8) | BIT(15);
+	col_piano_half_highlight_col2 = RGB15(13, 0, 0) | BIT(15);
 }
 
 Theme::Theme(char* themepath, bool use_fat)
@@ -180,6 +188,8 @@ bool Theme::parseTheme(FILE* theme_, u16* theme_cols) {
 
 	for (int l = 0; l < NUM_COLORS; ++l) {
 		parsed = fscanf(theme_, "%d=%02x%02x%02x%*[^\n]\n", &k, &r, &g, &b);
+		if (parsed == EOF)
+			break;
 
 		if (parsed != 4 || k < 0) {
 			debugprintf("theme parse error on line %d\n", l + 1);
@@ -193,10 +203,13 @@ bool Theme::parseTheme(FILE* theme_, u16* theme_cols) {
 		theme_i++;
 	}
 
-	if (theme_i < NUM_COLORS - 1) {
-		debugprintf("theme only specifies %u colors, need %u\n", theme_i, NUM_COLORS);
+	if (theme_i == 0) {
+		debugprintf("ignoring empty theme\n");
 		return false;
 	}
+		
+	if (theme_i < NUM_COLORS - 1)
+		debugprintf("theme only specifies %u colors, using defaults for remaining %u\n", theme_i, NUM_COLORS - theme_i);
 
 	return true;
 }


### PR DESCRIPTION
allows the piano to be themed and additionally allows themes with any amount of colours, using defaults otherwise

the piano palettes are now not initialised until `setTheme`, but they are also no longer read before that happens

