### PR TITLE
Piano theming, also allow incomplete themes

### DIFF
--- a/themes/Default.nttheme
+++ b/themes/Default.nttheme
@@ -82,3 +82,11 @@
 76=8394c5 ; Pattern - mute/solo gradient 2
 77=e67b00 ; Pattern - mute/solo gradient 1 (highlight)
 78=e6e600 ; Pattern - mute/solo gradient 2 (highlight)
+84=ffffff ; Piano - full key color 1
+85=cbcbcb ; Piano - full key color 2
+86=000000 ; Piano - half key color 1
+87=383838 ; Piano - half key color 2
+88=b2b2e3 ; Piano - full key color 1 (highlight)
+89=a2a2d3 ; Piano - full key color 2 (highlight)
+90=690000 ; Piano - half key color 1 (highlight)
+91=9a3838 ; Piano - half key color 2 (highlight)

--- a/themes/Default.nttheme
+++ b/themes/Default.nttheme
@@ -1,4 +1,5 @@
 0=20317b  ; Background
+1=20317b  ; Envelope editor background
 2=4a5a8b  ; Medium background
 3=8394c5  ; Light background
 4=bdcdff  ; Lighter background
@@ -12,8 +13,6 @@
 12=8394c5 ; List item gradient 2
 13=e67b00 ; List item gradient 1 (highlighted)
 14=e6e600 ; List item gradient 2 (highlighted)
-23=ffff00 ; List item separator line
-80=ffff00 ; List item separator line (vertical)
 15=4a5a8b ; Scrollbar background gradient 1
 16=8394c5 ; Scrollbar background gradient 2
 17=ff9400 ; Scrollbar thumb (inactive)
@@ -22,6 +21,7 @@
 20=ffff00 ; Scrollbar arrow background gradient 2
 21=000000 ; Widget outline
 22=000000 ; Tab/tab box outline
+23=ffff00 ; List item separator line
 24=000000 ; Tab icon
 25=000000 ; Button icon and scrollbar arrows
 26=000000 ; Checkmark
@@ -31,15 +31,11 @@
 30=000000 ; Text (value input)
 31=000000 ; Text (list items)
 32=000000 ; Text (highlighted list item)
-81=ff9400 ; Togglebutton background
-82=000000 ; Togglebutton text (off)
-83=ffff00 ; Togglebutton text (on)
 33=ff0000 ; Recording/signal (red)
 34=940000 ; Recording/signal (off, dark red)
 35=000000 ; Piano mapping label (naturals)
 36=ffffff ; Piano mapping label (inverted, sharps)
 37=39cd29 ; Loop points
-1=20317b  ; Envelope editor background
 38=00ff00 ; Envelope sustain line
 39=ff9400 ; Envelope line
 40=ffff00 ; Envelope point fill
@@ -63,7 +59,6 @@
 58=e67b00 ; Pattern - cursor bar gradient 1 (highlight)
 59=e6e600 ; Pattern - cursor bar gradient 2 (highlight)
 60=e67b00 ; Pattern - row numbers
-79=e67b00 ; Pattern - row numbers (highlight)
 61=4a7bff ; Pattern - notes
 62=0031d5 ; Pattern - notes (dark)
 63=ff5a00 ; Pattern - instruments
@@ -82,6 +77,11 @@
 76=8394c5 ; Pattern - mute/solo gradient 2
 77=e67b00 ; Pattern - mute/solo gradient 1 (highlight)
 78=e6e600 ; Pattern - mute/solo gradient 2 (highlight)
+79=e67b00 ; Pattern - row numbers (highlight)
+80=ffff00 ; List item separator line (vertical)
+81=ff9400 ; Togglebutton background
+82=000000 ; Togglebutton text (off)
+83=ffff00 ; Togglebutton text (on)
 84=ffffff ; Piano - full key color 1
 85=cbcbcb ; Piano - full key color 2
 86=000000 ; Piano - half key color 1

--- a/tobkit/include/tobkit/piano.h
+++ b/tobkit/include/tobkit/piano.h
@@ -45,17 +45,20 @@ class Piano: public Widget {
 		void showKeyLabels(void);
 		void hideKeyLabels(void);
 		void setKeyLabel(u8 key, char label);
-		
+		void setTheme(Theme *theme_, u16 bgcolor_);
+
 	private:
 		void (*onNote)(u8);
 		void (*onRelease)(u8, bool);
 		uint16 *char_base, *map_base;
 		
+		unsigned short piano_Palette[16], piano_fullnotehighlight_Palette[16], piano_halfnotehighlight_Palette[16];
+		
 		void draw(void);
 		void setKeyPal(u8 note);
 		u8 isHalfTone(u8 note);
 		void resetPals(void);
-		
+		void genPal(u16 *piano_cols_base, u16 *pal, u16 *pal_full_highlight, u16 *pal_half_highlight);
 		void drawKeyLabel(u8 key, bool visible=true);
 		void eraseKeyLabel(u8 key);
 		

--- a/tobkit/include/tobkit/theme.h
+++ b/tobkit/include/tobkit/theme.h
@@ -22,7 +22,7 @@ limitations under the License.
 #include "../../arm9/source/tools.h" 
 #include <nds.h>
 
-#define NUM_COLORS 84
+#define NUM_COLORS 92
 
 namespace tobkit {
 
@@ -114,6 +114,14 @@ struct ColorScheme {
 			u16 col_tb_bg;
 			u16 col_tb_fg_off;
 			u16 col_tb_fg_on;
+			u16 col_piano_full_col1;
+			u16 col_piano_full_col2;
+			u16 col_piano_half_col1;
+			u16 col_piano_half_col2;
+			u16 col_piano_full_highlight_col1;
+			u16 col_piano_full_highlight_col2;
+			u16 col_piano_half_highlight_col1;
+			u16 col_piano_half_highlight_col2;
 		};
 	};
 

--- a/tobkit/source/theme.cpp
+++ b/tobkit/source/theme.cpp
@@ -105,6 +105,14 @@ ColorScheme::ColorScheme() {
 	col_tb_bg = col_dark_ctrl;
 	col_tb_fg_off = col_text_bt;
 	col_tb_fg_on = col_light_ctrl;
+	col_piano_full_col1 = RGB15(31, 31, 31) | BIT(15);
+	col_piano_full_col2 = RGB15(25, 25, 25) | BIT(15);
+	col_piano_half_col1 = RGB15(8, 8, 8) | BIT(15);
+	col_piano_half_col2 = RGB15(0, 0, 0) | BIT(15);
+	col_piano_full_highlight_col1 = RGB15(24, 24, 30) | BIT(15);
+	col_piano_full_highlight_col2 = RGB15(20, 20, 26) | BIT(15);
+	col_piano_half_highlight_col1 = RGB15(20, 8, 8) | BIT(15);
+	col_piano_half_highlight_col2 = RGB15(13, 0, 0) | BIT(15);
 }
 
 Theme::Theme(char* themepath, bool use_fat)
@@ -180,6 +188,8 @@ bool Theme::parseTheme(FILE* theme_, u16* theme_cols) {
 
 	for (int l = 0; l < NUM_COLORS; ++l) {
 		parsed = fscanf(theme_, "%d=%02x%02x%02x%*[^\n]\n", &k, &r, &g, &b);
+		if (parsed == EOF)
+			break;
 
 		if (parsed != 4 || k < 0) {
 			debugprintf("theme parse error on line %d\n", l + 1);
@@ -193,10 +203,13 @@ bool Theme::parseTheme(FILE* theme_, u16* theme_cols) {
 		theme_i++;
 	}
 
-	if (theme_i < NUM_COLORS - 1) {
-		debugprintf("theme only specifies %u colors, need %u\n", theme_i, NUM_COLORS);
+	if (theme_i == 0) {
+		debugprintf("ignoring empty theme\n");
 		return false;
 	}
+		
+	if (theme_i < NUM_COLORS - 1)
+		debugprintf("theme only specifies %u colors, using defaults for remaining %u\n", theme_i, NUM_COLORS - theme_i);
 
 	return true;
 }


### PR DESCRIPTION
allows the piano to be themed and additionally allows themes with any amount of colours, using defaults otherwise

the piano palettes are now not initialised until `setTheme`, but they are also no longer read before that happens
