### PR TITLE
Sample playback cursor, various bug & ui fixes

### DIFF
--- a/arm9/source/main.cpp
+++ b/arm9/source/main.cpp
@@ -447,7 +447,7 @@ void onKeyrelease(void)
 {
 	// extracted into a function for pr153 compat
 	sampledisplay->eraseCursor();
-	sampledisplay->stopCursor(false);
+	sampledisplay->stopCursor(true);
 }
 
 void handleNoteStroke(u8 note)

--- a/arm9/source/main.cpp
+++ b/arm9/source/main.cpp
@@ -257,13 +257,19 @@ u8 dsmw_lastchannels[16] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 char last_themepath[SETTINGS_FILENAME_LEN + 1];
 
 bool fastscroll = false;
-
+bool multisamp_from_mapsamp = false;
 uint16* map;
 
 // TODO: Make own class for tracker control and remove forward declarations
 void handleButtons(u16 buttons, u16 buttonsheld);
 void HandleTick(void);
 void handlePotPosChangeFromSong(u16 newpotpos);
+void handleCursorPosChangeFromSong(u32 newcursorpos);
+void handleStopCursor(void);
+void sampleChange(Sample *smp);
+void handleSampleChange(u16 sample);
+void handleToggleMapSamples(bool on);
+void setMultisamplesEnabled(bool show);
 void drawMainScreen(void);
 void redrawSubScreen(void);
 void showMessage(const char *msg, bool error);
@@ -417,6 +423,33 @@ void handleNoteFill(u8 note, bool while_playing)
     }
 }
 
+// swap the sample display if the key has another
+// sample mapped then start the cursor
+void onKeypress(u8 note)
+{
+	Instrument *inst = song->getInstrument(state->instrument);
+	if (inst==0) return;
+	
+	// pr153 note: this assumes no polyphony and will play
+	// the last note pressed in a chord and draw only one cursor
+	// for that/switch to it. Could be updated in future to draw
+	// multiple concurrent cursors
+	u16 newsamp = inst->getNoteSample(note + state->basenote);
+
+	handleSampleChange(newsamp);
+	lbsamples->select(newsamp);
+
+	if (!inst->getSampleForNote(note)) return;
+	sampledisplay->startCursor(note); // don't call this in sampleChange as lbsamples doesn't play the note
+}
+
+void onKeyrelease(void)
+{
+	// extracted into a function for pr153 compat
+	sampledisplay->eraseCursor();
+	sampledisplay->stopCursor(false);
+}
+
 void handleNoteStroke(u8 note)
 {
 	if (note == EMPTY_NOTE || note == STOP_NOTE) return;
@@ -447,6 +480,9 @@ void handleNoteStroke(u8 note)
 		label = (sample_id >= 0xA) ? (sample_id - 0xA + 'a') : (sample_id + '0');
 		kb->setKeyLabel(note, label);
 	}
+	
+	// after pr153 merge: also add this to handlePianoPakStroke
+	onKeypress(note); 
 
 	// Play the note
 	// Send "play inst" command
@@ -477,6 +513,8 @@ void handleNoteRelease(u8 note, bool moved)
 		redraw_main_requested = true;
 	}
 
+	// after pr153 merge: also add this to handlePianoPakRelease
+	onKeyrelease();
 	CommandStopInst(255);
 
 #ifdef MIDI
@@ -531,6 +569,23 @@ void updateFilesystemState(bool draw)
 
 void sampleChange(Sample *smp)
 {
+	rbloop_none->set_enabled(smp != NULL);
+	rbloop_forward->set_enabled(smp != NULL);
+	rbloop_pingpong->set_enabled(smp != NULL);
+	nssamplevolume->set_enabled(smp != NULL);
+	nspanning->set_enabled(smp != NULL);
+	nsrelnote->set_enabled(smp != NULL);
+	nsfinetune->set_enabled(smp != NULL);
+	buttonsmpfadein->set_enabled(smp != NULL);
+	buttonsmpfadeout->set_enabled(smp != NULL);
+	buttonsmpselall->set_enabled(smp != NULL);
+	buttonsmpselnone->set_enabled(smp != NULL);
+	buttonsmpseldel->set_enabled(smp != NULL);
+	buttonsmpreverse->set_enabled(smp != NULL);
+	buttonsmpnormalize->set_enabled(smp != NULL);
+	cbsnapto0xing->set_enabled(smp != NULL);
+	buttonsmpdraw->set_enabled(smp != NULL);
+
 	if(smp == NULL)
 	{
 		sampledisplay->setSample(NULL);
@@ -589,6 +644,12 @@ void volEnvSetInst(Instrument *inst)
 	btnenvdrawmode->set_enabled(inst != NULL);
 	btnaddenvpoint->set_enabled(inst != NULL);
 	btndelenvpoint->set_enabled(inst != NULL);
+	btnenvzoomin->set_enabled(inst != NULL);
+	btnenvzoomout->set_enabled(inst != NULL);
+	btnenvsetsuspoint->set_enabled(inst != NULL);
+	cbvolenvenabled->set_enabled(inst != NULL);
+	cbsusenabled->set_enabled(inst != NULL);
+	tbmapsamples->set_enabled(inst != NULL);
 	volenvedit->pleaseDraw();
 }
 
@@ -622,6 +683,7 @@ void handleInstChange(u16 newinst)
 	}
 	else
 	{
+		state->sample = 0;
 		sampleChange(NULL);
 		return;
 	}
@@ -1326,6 +1388,20 @@ void handlePotPosChangeFromSong(u16 newpotpos)
 
 	// Update other GUI Elements
 	updateGuiToNewPattern(song->getPotEntry(state->potpos));
+}
+
+void handleCursorPosChangeFromSong(u32 newcursorpos)
+{
+	if (sampledisplay==0) return;
+
+	sampledisplay->updateCursorPos(newcursorpos);
+}
+
+void handleStopCursor(void)
+{
+	if (sampledisplay==0) return;
+
+	sampledisplay->stopCursor(false);
 }
 
 #ifdef MIDI
@@ -2096,25 +2172,14 @@ void handleToggleScrollLock(bool on)
 
 void handleToggleMultiSample(bool on)
 {
-	if(on)
-	{
-		drawSampleNumbers();
-		kb->showKeyLabels();
-		tbmultisample->setCaption("-");
-		lbinstruments->resize(114, 67);
-		buttonrenamesample->show();
-		lbsamples->show();
-		tbmapsamples->show();
+	multisamp_from_mapsamp = false;
+
+	if (!on) {
+		handleToggleMapSamples(false);
+		tbmapsamples->setState(false);
 	}
-	else
-	{
-		kb->hideKeyLabels();
-		tbmultisample->setCaption("+");
-		buttonrenamesample->hide();
-		lbsamples->hide();
-		lbinstruments->resize(114, 89);
-		tbmapsamples->hide();
-	}
+		
+	setMultisamplesEnabled(on);
 }
 
 void showTypewriterForSampleRename(void)
@@ -2733,7 +2798,28 @@ void saveConfig(void)
 		showMessage("config saved!", false);
 }
 
-void toggleMapSamples(bool is_active)
+void setMultisamplesEnabled(bool show)
+{
+	if (show)
+	{
+		drawSampleNumbers();
+		kb->showKeyLabels();
+		lbinstruments->resize(114, 67);
+		lbsamples->show();
+	}
+		
+	else {
+		lbsamples->hide();
+		lbinstruments->resize(114, 89);
+		kb->hideKeyLabels();
+	}
+
+	tbmultisample->setCaption(show ? "-" : "+");
+	tbmultisample->setState(show);
+	buttonrenamesample->set_visible(show);
+}
+
+void handleToggleMapSamples(bool is_active)
 {
 	Instrument *inst = song->getInstrument(state->instrument);
 	if(inst == NULL)
@@ -2741,11 +2827,17 @@ void toggleMapSamples(bool is_active)
 
 	if(is_active)
 	{
-		if(tbmultisample->getState() == false)
-			tbmultisample->setState(true);
+		if(tbmultisample->getState() == false) {
+			setMultisamplesEnabled(true);
+			multisamp_from_mapsamp = true;
+		}
+	} else {
+		if (multisamp_from_mapsamp)
+			setMultisamplesEnabled(false);
 	}
 
 	state->map_samples = is_active;
+	kb->setInMappingMode(is_active);
 }
 
 void toggleQueueLock(bool is_active)
@@ -3274,9 +3366,10 @@ void setupGUI(bool dldi_enabled)
     cbsusenabled->setCaption("sus on");
     cbsusenabled->registerToggleCallback(envToggleSustainEnabled);
     
-		tbmapsamples = new ToggleButton(72, 133, 134-72, 12, &sub_vram, false);
+		tbmapsamples = new ToggleButton(72, 133, 134-72, 12, &sub_vram);
 		tbmapsamples->setCaption("map samp.");
-		tbmapsamples->registerToggleCallback(toggleMapSamples);
+		tbmapsamples->registerToggleCallback(handleToggleMapSamples);
+		tbmapsamples->disable();
 
 		tabbox->registerWidget(btnaddenvpoint, 0, 3);
 		tabbox->registerWidget(btndelenvpoint, 0, 3);
@@ -3610,7 +3703,7 @@ void setupGUI(bool dldi_enabled)
 
 	gui->revealAll();
 
-
+	sampleChange(NULL); // disable samp ed buttons at first as we have no sample!
 	actionBufferChangeCallback();
 	updateTempoAndBpm();
 	handleLinesBeatChange(settings->getLinesPerBeat());
@@ -3734,6 +3827,9 @@ void VblankHandler(void)
 	u16 keysup = keysUp();
 	u16 keysheld = keysHeld();
 	touchRead(&touch);
+
+	if (sampledisplay != NULL && sampledisplay->getIsExposed())
+		sampledisplay->drawCursor();
 
 	if(keysdown & KEY_TOUCH)
 	{
@@ -4034,6 +4130,8 @@ int main(int argc, char **argv) {
 	RegisterStopCallback(handleStop);
 	RegisterPlaySampleFinishedCallback(handlePreviewSampleFinished);
 	RegisterPotPosChangeCallback(handlePotPosChangeFromSong);
+	RegisterCursorPosChangeCallback(handleCursorPosChangeFromSong);
+	RegisterStopCursorCallback(handleStopCursor);
 
 	setupSong();
 

--- a/arm9/source/tobkit/numbersliderrelnote.cpp
+++ b/arm9/source/tobkit/numbersliderrelnote.cpp
@@ -48,6 +48,7 @@ void NumberSliderRelNote::pleaseDraw(void) {
 // Event calls
 void NumberSliderRelNote::penDown(u8 px, u8 py)
 {
+	if (!enabled) return;
 	if((px>x)&&(px<x+32)&&(py>y)&&(py<y+17)) {
 		btnstate = true;
 		lasty = py;
@@ -58,12 +59,14 @@ void NumberSliderRelNote::penDown(u8 px, u8 py)
 
 void NumberSliderRelNote::penUp(u8 px, u8 py)
 {
+	if (!enabled) return;
 	btnstate = false;
 	draw();
 }
 
 void NumberSliderRelNote::penMove(u8 px, u8 py)
 {
+	if (!enabled) return;
 	s16 dy = lasty-py;
 	if(abs(dy)>3) {
 		s16 newval = value+dy/4;
@@ -111,11 +114,13 @@ void NumberSliderRelNote::draw(void)
 	if(!isExposed())
 		return;
 	
+	u16 col_light = enabled ? theme->col_light_ctrl : theme->col_light_ctrl_disabled;
+	u16 col_dark = enabled ? theme->col_dark_ctrl : theme->col_dark_ctrl_disabled;
 	// Slider thingy
 	if(btnstate==true) {
-		drawGradient(theme->col_dark_ctrl, theme->col_light_ctrl, 1, 1, 8, 15);
+		drawGradient(col_dark, col_light, 1, 1, 8, 15);
 	} else {
-		drawGradient(theme->col_light_ctrl, theme->col_dark_ctrl, 1, 1, 8, 15);
+		drawGradient(col_light, col_dark, 1, 1, 8, 15);
 	}
 	
 	// This draws the up-arrow

--- a/arm9/source/tobkit/sampledisplay.cpp
+++ b/arm9/source/tobkit/sampledisplay.cpp
@@ -43,14 +43,20 @@ SampleDisplay::SampleDisplay(u8 _x, u8 _y, u8 _width, u8 _height, u16 **_vram, S
 	pen_on_zoom_in(false), pen_on_zoom_out(false),
 	pen_on_scroll_left(false), pen_on_scroll_right(false), pen_on_scrollthingy(false), pen_on_scrollbar(false),
 	scrollthingypos(0), scrollthingywidth(width-2*SCROLLBUTTON_HEIGHT+2), pen_x_on_scrollthingy(0), zoom_level(0), scrollpos(0),
-	snap_to_zero_crossings(true), draw_mode(false)
+	snap_to_zero_crossings(true), draw_mode(false), currentSampleFreq(0), playing(false), last_cursor_draw_x(0)
 {
-
+	for (int i = 0; i < DRAW_HEIGHT_S + 1; ++i) {
+		previous_cursor_pixels[i] = 0;
+	}
 }
 
 SampleDisplay::~SampleDisplay(void)
 {
-
+}
+void SampleDisplay::setTheme(Theme *theme_, u16 bgcolor_)
+{
+	last_cursor_draw_x = 0;
+	Widget::setTheme(theme_, bgcolor_);
 }
 
 void SampleDisplay::penDown(u8 px, u8 py)
@@ -62,6 +68,7 @@ void SampleDisplay::penDown(u8 px, u8 py)
 		draw_last_x = px - x;
 		draw_last_y = py - y;
 	} else {
+		last_cursor_draw_x = 0;
 		// Stylus on a loop point?
 		u32 loop_start_pos = sampleToPixel(smp->getLoopStart());//smp->getLoopStart() * (width-2) / smp->getNSamples();
 		u32 loop_end_pos   = sampleToPixel(smp->getLoopStart() + smp->getLoopLength());//(smp->getLoopStart() + smp->getLoopLength()) * (width-2) / smp->getNSamples();
@@ -229,6 +236,7 @@ void SampleDisplay::penMove(u8 px, u8 py)
 void SampleDisplay::setSample(Sample *_smp)
 {
 	smp = _smp;
+	last_cursor_draw_x = 0; // dont draw under-cursor-buffer over other sample
 	selection_exists = false;
 	selstart = selend = 0;
 	if(_smp == 0) {
@@ -316,7 +324,83 @@ void SampleDisplay::setSnapToZeroCrossing(bool snap)
 	snap_to_zero_crossings = snap;
 }
 
+void SampleDisplay::stopCursor(bool full_redraw = false)  {
+	playing = false;
+	if (full_redraw && last_cursor_draw_x != 0) { // don't redraw if we never drew the cursor
+		draw();
+		last_cursor_draw_x = 0; // use 0 when we want to skip restoring under-cursor pixels
+	}
+}
+
+// commented out sections facilitating for 09xx command support
+// if/when it is added
+void SampleDisplay::startCursor(u8 note/*, u32 offs_raw*/)  {
+	// setOffsetRaw(offs_raw);
+	if (smp == NULL) 
+	{
+		printf("NULL SAMPLE\n");
+		return;
+	}
+	stopCursor(true); // stop previous cursor if necessary
+	playing = true;
+	// if (_samp != smp) { 		// <- necessary if the behaviour is retained where
+	// 	eraseCursor();     		//    pressing different multisample keys does not update the wave disp
+	// 	return;					//    according to that sample
+	// }
+}
+
+
 /* ===================== PRIVATE ===================== */
+
+// backup the pixels that are about to be overwritten
+// by the cursor and only restore those when it moves,
+// rather than drawing the entire sample box every time
+void SampleDisplay::eraseCursor(void)
+{
+	if (last_cursor_draw_x != 0)
+		for (int i = 0; i < DRAW_HEIGHT + 1; ++i) {
+			*(*vram + SCREEN_WIDTH * (y + i + 1) + x + last_cursor_draw_x) = previous_cursor_pixels[i];
+		}
+}
+
+void SampleDisplay::updateCursorPos(u32 newCursorPos)
+{
+	position_samps = newCursorPos;
+}
+
+void SampleDisplay::drawCursor(void)
+{
+	if (smp==0) return;
+	
+	if (position_samps != 0) {
+		u32 drawpix = sampleToPixel((position_samps));
+		// draw the previous pixels on the previous cursor pos
+		eraseCursor();
+		if (drawpix < x + width) {
+			s32 draw_at_x = sampleToPixel(position_samps);
+
+			u16 col_cursor = theme->col_env_sustain;
+
+			if (!playing)
+				return;
+				
+			// backup pixels that were underneath the cursor
+			if (last_cursor_draw_x != (u32)draw_at_x) {
+				last_cursor_draw_x = (u32)draw_at_x;
+				for(int i=0;i<DRAW_HEIGHT + 1;++i)
+					previous_cursor_pixels[i] = *(*vram+SCREEN_WIDTH*(y+i+1)+x+draw_at_x);
+			}
+
+			// ...and finally, draw the cursor itself
+			if (!(draw_at_x >= width + 1) && draw_at_x != 0) {
+				for(int i=0;i<DRAW_HEIGHT+1;++i) {
+					*(*vram+SCREEN_WIDTH*(y+i+1)+x+draw_at_x) = col_cursor;
+				}
+			}
+		}
+	}
+}
+
 
 long SampleDisplay::find_zero_crossing_near(long pos)
 {

--- a/arm9/source/tobkit/sampledisplay.h
+++ b/arm9/source/tobkit/sampledisplay.h
@@ -41,6 +41,7 @@ namespace tobkit {
 #define SCROLLPIXELS				25 // Scroll that many pixels when a scroll button is pressed
 #define MIN_SCROLLTHINGY_WIDTH		15
 #define DRAW_HEIGHT					(height-SCROLLBUTTON_HEIGHT-2) // height of the visible window
+#define DRAW_HEIGHT_S				(70-SCROLLBUTTON_HEIGHT-2) // available at compile time
 
 class SampleDisplay: public Widget {
 	public:
@@ -57,9 +58,15 @@ class SampleDisplay: public Widget {
 		void pleaseDraw(void);
 
 		void setSample(Sample *_smp);
-
+		bool getIsExposed(void) { return isExposed(); }
 		void select_all(void);
 		void clear_selection(void);
+
+		void updateCursorPos(u32 newCursorPos);
+		void drawCursor(void);
+		void startCursor(u8 note=NULL/*, u32 offset_raw_ = 0*/);
+		void stopCursor(bool full_redraw);
+		void eraseCursor(void);
 
 		// Return start and end sample of selection
 		bool getSelection(u32 *startsample, u32 *endsample);
@@ -80,10 +87,12 @@ class SampleDisplay: public Widget {
 		long find_zero_crossing_near(long pos);
 
 		void draw(void);
+		void setTheme(Theme *theme_, u16 bgcolor_);
 		void scroll(u32 newscrollpos);
 		void calcScrollThingy(void);
 		void zoomIn(void);
 		void zoomOut(void);
+
 		u32 pixelToSample(s32 pixel);
 		s32 sampleToPixel(u32 sample);
 
@@ -118,6 +127,13 @@ class SampleDisplay: public Widget {
 		bool draw_mode;
 
 		u8 draw_last_x, draw_last_y;
+
+		
+		u32 currentSampleFreq;
+		u32 position_samps;
+		bool playing;
+		u32 last_cursor_draw_x;
+		u16 previous_cursor_pixels[DRAW_HEIGHT_S + 1];
 };
 
 };

--- a/tobkit/include/tobkit/piano.h
+++ b/tobkit/include/tobkit/piano.h
@@ -45,6 +45,7 @@ class Piano: public Widget {
 		void showKeyLabels(void);
 		void hideKeyLabels(void);
 		void setKeyLabel(u8 key, char label);
+		void setInMappingMode(bool instmap);
 		void setTheme(Theme *theme_, u16 bgcolor_);
 
 	private:
@@ -64,6 +65,7 @@ class Piano: public Widget {
 		
 		char key_labels[24];
 		bool key_labels_visible;
+		bool mapping_instrument;
 		u16 curr_note;
 };
 

--- a/tobkit/source/bitbutton.cpp
+++ b/tobkit/source/bitbutton.cpp
@@ -54,6 +54,7 @@ void BitButton::penDown(u8 x, u8 y)
 
 void BitButton::penUp(u8 x, u8 y)
 {
+	if (!enabled) return;
 	penIsDown = false;
 	draw(0);
 	if(onPush) {

--- a/tobkit/source/button.cpp
+++ b/tobkit/source/button.cpp
@@ -48,12 +48,14 @@ void Button::pleaseDraw(void) {
 // Event calls
 void Button::penDown(u8 x, u8 y)
 {
+	if (!enabled) return;
 	penIsDown = true;
 	draw(1);
 }
 
 void Button::penUp(u8 x, u8 y)
 {
+	if (!enabled) return;
 	penIsDown = false;
 	draw(0);
 	if(onPush) {

--- a/tobkit/source/numberslider.cpp
+++ b/tobkit/source/numberslider.cpp
@@ -40,6 +40,8 @@ void NumberSlider::pleaseDraw(void) {
 // Event calls
 void NumberSlider::penDown(u8 px, u8 py)
 {
+	if (!enabled) return;
+
 	if((px>x)&&(px<x+32)&&(py>y)&&(py<y+17)) {
 		btnstate = true;
 		lasty = py;
@@ -68,6 +70,8 @@ void NumberSlider::penDown(u8 px, u8 py)
 
 void NumberSlider::penUp(u8 px, u8 py)
 {
+	if (!enabled) return;
+
 	btnstate = false;
 
 	if(onPostChange!=0) {
@@ -79,6 +83,8 @@ void NumberSlider::penUp(u8 px, u8 py)
 
 void NumberSlider::penMove(u8 px, u8 py)
 {
+	if (!enabled) return;
+
 	s16 dy = lasty-py;
 	if(abs(dy)>1) {
 		int inc = dy*dy/8;
@@ -146,15 +152,17 @@ void NumberSlider::registerChangeCallback(void (*onChange_)(s32)) {
 
 void NumberSlider::draw(void)
 {
-	
 	if(!isExposed())
 		return;
-	
+
+	u16 col_light = enabled ? theme->col_light_ctrl : theme->col_light_ctrl_disabled;
+	u16 col_dark = enabled ? theme->col_dark_ctrl : theme->col_dark_ctrl_disabled;
+	drawGradient(col_light, col_dark ,2, 2, 7, 7);
 	// Slider thingy
 	if(btnstate==true) {
-		drawGradient(theme->col_dark_ctrl, theme->col_light_ctrl, 1, 1, 8, 15);
+		drawGradient(col_dark, col_light, 1, 1, 8, 15);
 	} else {
-		drawGradient(theme->col_light_ctrl, theme->col_dark_ctrl, 1, 1, 8, 15);
+		drawGradient(col_light, col_dark, 1, 1, 8, 15);
 	}
 	
 	// This draws the up-arrow

--- a/tobkit/source/radiobutton.cpp
+++ b/tobkit/source/radiobutton.cpp
@@ -35,6 +35,7 @@ void RadioButton::pleaseDraw(void) {
 
 // Event calls
 void RadioButton::penDown(u8 px, u8 py) {
+	if (!enabled) return;
 	rbg->pushed(this);
 }
 
@@ -60,9 +61,12 @@ bool RadioButton::getActive(void) {
 
 void RadioButton::draw(void)
 {
+	if (!isExposed()) return;
 	// Draw the dot
 	//drawFullBox(2, 2, 7, 7, col);
-	drawGradient(theme->col_light_ctrl, theme->col_dark_ctrl ,2, 2, 7, 7);
+	u16 col_light = enabled ? theme->col_light_ctrl : theme->col_light_ctrl_disabled;
+	u16 col_dark = enabled ? theme->col_dark_ctrl : theme->col_dark_ctrl_disabled;
+	drawGradient(col_light, col_dark ,2, 2, 7, 7);
 	
 	drawHLine(3, 1, 5, theme->col_outline);
 	drawHLine(3, 9, 5, theme->col_outline);

--- a/tobkit/source/tabbox.cpp
+++ b/tobkit/source/tabbox.cpp
@@ -181,8 +181,9 @@ void TabBox::draw(void)
 
 			drawFullBox(3+size_full*guiidx, 1+offset, size_border, size_border-offset, selected ? theme->col_selected_tab : theme->col_unselected_tab);
 			drawVLine(2+size_full*guiidx, 1+offset, size_border-offset, black);
-			drawHLine(3+size_full*guiidx, 0+offset, size_border, black);
+			drawHLine(3+size_full*guiidx, 0+offset, size_border - 1, black);
 			drawVLine(2+size_full*(guiidx+1), 1+offset, size_border-offset, black);
+			if (!selected) drawPixel(3+size_full*guiidx+size_border-1, 0+offset, theme->col_bg);
 			drawMonochromeIcon(4+size_full*guiidx, 2+offset, icon_size, icon_size - offset, icons.at(guiidx), theme->col_icon);
 		}
 	} else {
@@ -200,7 +201,8 @@ void TabBox::draw(void)
 			drawFullBox(1+offset, 2+size_full*guiidx, size_border-offset, size_border, selected ? theme->col_selected_tab : theme->col_unselected_tab);
 			drawHLine(1+offset, 2+size_full*guiidx, size_border-offset, black);
 			drawVLine(0+offset, 3+size_full*guiidx, size_border - 1, black);
-			drawHLine(1+offset, 2+size_full*(guiidx+1), size_border-offset, black);
+			drawHLine(1+offset, 2+size_full*(guiidx+1), size_border-offset-1, black);
+			if (!selected) drawPixel(offset, 2+size_full*guiidx + size_border, theme->col_light_bg);
 			drawMonochromeIconOffset(2+offset, 4+size_full*guiidx, icon_size - offset, icon_size, 0, 0, icon_size, icon_size, icons.at(guiidx), theme->col_icon);
 		}
 	}

--- a/tobkit/source/theme.cpp
+++ b/tobkit/source/theme.cpp
@@ -107,8 +107,8 @@ ColorScheme::ColorScheme() {
 	col_tb_fg_on = col_light_ctrl;
 	col_piano_full_col1 = RGB15(31, 31, 31) | BIT(15);
 	col_piano_full_col2 = RGB15(25, 25, 25) | BIT(15);
-	col_piano_half_col1 = RGB15(8, 8, 8) | BIT(15);
-	col_piano_half_col2 = RGB15(0, 0, 0) | BIT(15);
+	col_piano_half_col1 = RGB15(0, 0, 0) | BIT(15);
+	col_piano_half_col2 = RGB15(8, 8, 8) | BIT(15);
 	col_piano_full_highlight_col1 = RGB15(24, 24, 30) | BIT(15);
 	col_piano_full_highlight_col2 = RGB15(20, 20, 26) | BIT(15);
 	col_piano_half_highlight_col1 = RGB15(20, 8, 8) | BIT(15);
@@ -168,14 +168,14 @@ bool Theme::stringToRGB15(char* str, u16* col)
 	int res = sscanf(str, "%02x%02x%02x", &r, &g, &b);
 	if (res < 3)
 		return false;
-	*col = (u16)(RGB15(r * 31 / 255, g * 31 / 255, b * 31 / 255) | BIT(15));
+	*col = (u16)(RGB15(r >> 3, g >> 3, b >> 3) | BIT(15));
 	return true;
 }
 
 // not needed as we are not writing themes currently
 void Theme::RGB15ToString(u16 col, char* str)
 {
-	sprintf(str, "%02x%02x%02x", (col & 0x1f) * 255 / 31, ((col >> 5) & 0x1f) * 255 / 31, (col >> 10 & 0x1f) * 255 / 31);
+	sprintf(str, "%02x%02x%02x", (col & 0x1f) << 3, ((col >> 5) & 0x1f) << 3, (col >> 10 & 0x1f) << 3);
 }
 
 
@@ -199,7 +199,7 @@ bool Theme::parseTheme(FILE* theme_, u16* theme_cols) {
 			debugprintf("theme parse error on line %d (key out of bounds, max %d)  \n", l + 1, NUM_COLORS - 1);
 			return false;
 		}
-		theme_cols[k] = RGB15(r * 31 / 255, g * 31 / 255, b * 31 / 255) | BIT(15);
+		theme_cols[k] = RGB15(r >> 3, g >> 3, b >> 3) | BIT(15);
 		theme_i++;
 	}
 

--- a/tobkit/source/togglebutton.cpp
+++ b/tobkit/source/togglebutton.cpp
@@ -50,6 +50,7 @@ void ToggleButton::pleaseDraw(void) {
 // Event calls
 void ToggleButton::penDown(u8 x, u8 y)
 {
+	if (!enabled) return;
 	penIsDown = true;
 	on = !on;
 	draw();
@@ -113,12 +114,12 @@ bool ToggleButton::getState(void)
 void ToggleButton::draw(void)
 {
 	if(!isExposed()) return;
-
-	u16 bg = theme->col_tb_bg;
+	u16 bg = enabled ? theme->col_tb_bg : theme->col_dark_ctrl_disabled;
 	drawFullBox(1, 1, width - 2, height - 2, bg);
 	drawBorder(theme->col_outline);
-
+	
 	u16 col;
+
 	if(penIsDown) {
 		if(on) {
 			col = bg;


### PR DESCRIPTION
Initially started out this PR as a rewrite of the sample cursor but also fixed a few inconsistencies/bugs relating to mapping keys.

Requires https://github.com/NitrousTracker/libntxm/pull/18

Below is a short list of the changes I have made, with more info in review comments:
* Sample playback cursor, the position of which is calculated by arm7 then drawn every vblank so it stays in sync
* Switch the currently displayed/selected sample based on the multisample note just played
* Fix/implement the display and functioning of disabled state for many more widgets
* Do not hide the map samples button when the listbox for samples is not shown (see review comments for more info)
* Disable unusable controls within the sample and envelope editors if the current (sample/instrument) is null
* Fix a bug regarding drawing mapping labels when in mapping mode but after disabling the sample listbox
* Fix minor display bug with the tabbox where after deselecting a tab the rounding disappears
* Fix slightly inaccurate theme colour calc
* Fix the `genPal` drawing the default piano slightly differently to the original default theme (whoops my bad lol) 
* fix a slight inconsistency regarding the current sample when clicking on a new instrument which should reset it to 0, but only did so visually

Also, regarding https://github.com/NitrousTracker/nitroustracker/pull/153, when it is implemented minor changes would have to be made to the way this works, however I left them as commetns when necessary. 

Video showing most of the changes + the operation of the cursor:

https://github.com/user-attachments/assets/52c6dcad-3f02-48f3-9836-8a113f4dd00a


Also fixes the theme colour calculation - rgb24 has 256 values and rgb15 has 32 values so the calculation needs to be 256/32 (8), not 255/31 / 31/255, which caused the UI to be darkened if using the default theme from its file. I just changed it to divide using a bitshift. Attached below is a screenshot of the difference (left: original/fix, right: darker):

<img width="512" height="768" alt="ertwwertewtwet" src="https://github.com/user-attachments/assets/0a740485-b984-4ea0-b8f9-03298a2b7618" />

Very sorry for including so many changes in the same merge request, I kind of got caught up fixing one specific thing relating to mapping and they're all a bit entangled with each other
