### PR TITLE
Various small bug/ui fixes

### DIFF
--- a/arm9/source/tobkit/numbersliderrelnote.cpp
+++ b/arm9/source/tobkit/numbersliderrelnote.cpp
@@ -48,6 +48,7 @@ void NumberSliderRelNote::pleaseDraw(void) {
 // Event calls
 void NumberSliderRelNote::penDown(u8 px, u8 py)
 {
+	if (!enabled) return;
 	if((px>x)&&(px<x+32)&&(py>y)&&(py<y+17)) {
 		btnstate = true;
 		lasty = py;
@@ -58,12 +59,14 @@ void NumberSliderRelNote::penDown(u8 px, u8 py)
 
 void NumberSliderRelNote::penUp(u8 px, u8 py)
 {
+	if (!enabled) return;
 	btnstate = false;
 	draw();
 }
 
 void NumberSliderRelNote::penMove(u8 px, u8 py)
 {
+	if (!enabled) return;
 	s16 dy = lasty-py;
 	if(abs(dy)>3) {
 		s16 newval = value+dy/4;
@@ -111,11 +114,13 @@ void NumberSliderRelNote::draw(void)
 	if(!isExposed())
 		return;
 	
+	u16 col_light = enabled ? theme->col_light_ctrl : theme->col_light_ctrl_disabled;
+	u16 col_dark = enabled ? theme->col_dark_ctrl : theme->col_dark_ctrl_disabled;
 	// Slider thingy
 	if(btnstate==true) {
-		drawGradient(theme->col_dark_ctrl, theme->col_light_ctrl, 1, 1, 8, 15);
+		drawGradient(col_dark, col_light, 1, 1, 8, 15);
 	} else {
-		drawGradient(theme->col_light_ctrl, theme->col_dark_ctrl, 1, 1, 8, 15);
+		drawGradient(col_light, col_dark, 1, 1, 8, 15);
 	}
 	
 	// This draws the up-arrow

--- a/tobkit/include/tobkit/piano.h
+++ b/tobkit/include/tobkit/piano.h
@@ -45,6 +45,7 @@ class Piano: public Widget {
 		void showKeyLabels(void);
 		void hideKeyLabels(void);
 		void setKeyLabel(u8 key, char label);
+		void setInMappingMode(bool instmap);
 		void setTheme(Theme *theme_, u16 bgcolor_);
 
 	private:
@@ -64,6 +65,7 @@ class Piano: public Widget {
 		
 		char key_labels[24];
 		bool key_labels_visible;
+		bool mapping_instrument;
 		u16 curr_note;
 };
 

--- a/tobkit/source/bitbutton.cpp
+++ b/tobkit/source/bitbutton.cpp
@@ -54,6 +54,7 @@ void BitButton::penDown(u8 x, u8 y)
 
 void BitButton::penUp(u8 x, u8 y)
 {
+	if (!enabled) return;
 	penIsDown = false;
 	draw(0);
 	if(onPush) {

--- a/tobkit/source/button.cpp
+++ b/tobkit/source/button.cpp
@@ -48,12 +48,14 @@ void Button::pleaseDraw(void) {
 // Event calls
 void Button::penDown(u8 x, u8 y)
 {
+	if (!enabled) return;
 	penIsDown = true;
 	draw(1);
 }
 
 void Button::penUp(u8 x, u8 y)
 {
+	if (!enabled) return;
 	penIsDown = false;
 	draw(0);
 	if(onPush) {

--- a/tobkit/source/numberslider.cpp
+++ b/tobkit/source/numberslider.cpp
@@ -40,6 +40,8 @@ void NumberSlider::pleaseDraw(void) {
 // Event calls
 void NumberSlider::penDown(u8 px, u8 py)
 {
+	if (!enabled) return;
+
 	if((px>x)&&(px<x+32)&&(py>y)&&(py<y+17)) {
 		btnstate = true;
 		lasty = py;
@@ -68,6 +70,8 @@ void NumberSlider::penDown(u8 px, u8 py)
 
 void NumberSlider::penUp(u8 px, u8 py)
 {
+	if (!enabled) return;
+
 	btnstate = false;
 
 	if(onPostChange!=0) {
@@ -79,6 +83,8 @@ void NumberSlider::penUp(u8 px, u8 py)
 
 void NumberSlider::penMove(u8 px, u8 py)
 {
+	if (!enabled) return;
+
 	s16 dy = lasty-py;
 	if(abs(dy)>1) {
 		int inc = dy*dy/8;
@@ -146,15 +152,17 @@ void NumberSlider::registerChangeCallback(void (*onChange_)(s32)) {
 
 void NumberSlider::draw(void)
 {
-	
 	if(!isExposed())
 		return;
-	
+
+	u16 col_light = enabled ? theme->col_light_ctrl : theme->col_light_ctrl_disabled;
+	u16 col_dark = enabled ? theme->col_dark_ctrl : theme->col_dark_ctrl_disabled;
+	drawGradient(col_light, col_dark ,2, 2, 7, 7);
 	// Slider thingy
 	if(btnstate==true) {
-		drawGradient(theme->col_dark_ctrl, theme->col_light_ctrl, 1, 1, 8, 15);
+		drawGradient(col_dark, col_light, 1, 1, 8, 15);
 	} else {
-		drawGradient(theme->col_light_ctrl, theme->col_dark_ctrl, 1, 1, 8, 15);
+		drawGradient(col_light, col_dark, 1, 1, 8, 15);
 	}
 	
 	// This draws the up-arrow

--- a/tobkit/source/radiobutton.cpp
+++ b/tobkit/source/radiobutton.cpp
@@ -35,6 +35,7 @@ void RadioButton::pleaseDraw(void) {
 
 // Event calls
 void RadioButton::penDown(u8 px, u8 py) {
+	if (!enabled) return;
 	rbg->pushed(this);
 }
 
@@ -60,9 +61,12 @@ bool RadioButton::getActive(void) {
 
 void RadioButton::draw(void)
 {
+	if (!isExposed()) return;
 	// Draw the dot
 	//drawFullBox(2, 2, 7, 7, col);
-	drawGradient(theme->col_light_ctrl, theme->col_dark_ctrl ,2, 2, 7, 7);
+	u16 col_light = enabled ? theme->col_light_ctrl : theme->col_light_ctrl_disabled;
+	u16 col_dark = enabled ? theme->col_dark_ctrl : theme->col_dark_ctrl_disabled;
+	drawGradient(col_light, col_dark ,2, 2, 7, 7);
 	
 	drawHLine(3, 1, 5, theme->col_outline);
 	drawHLine(3, 9, 5, theme->col_outline);

--- a/tobkit/source/tabbox.cpp
+++ b/tobkit/source/tabbox.cpp
@@ -181,8 +181,9 @@ void TabBox::draw(void)
 
 			drawFullBox(3+size_full*guiidx, 1+offset, size_border, size_border-offset, selected ? theme->col_selected_tab : theme->col_unselected_tab);
 			drawVLine(2+size_full*guiidx, 1+offset, size_border-offset, black);
-			drawHLine(3+size_full*guiidx, 0+offset, size_border, black);
+			drawHLine(3+size_full*guiidx, 0+offset, size_border - 1, black);
 			drawVLine(2+size_full*(guiidx+1), 1+offset, size_border-offset, black);
+			if (!selected) drawPixel(3+size_full*guiidx+size_border-1, 0+offset, theme->col_bg);
 			drawMonochromeIcon(4+size_full*guiidx, 2+offset, icon_size, icon_size - offset, icons.at(guiidx), theme->col_icon);
 		}
 	} else {
@@ -200,7 +201,8 @@ void TabBox::draw(void)
 			drawFullBox(1+offset, 2+size_full*guiidx, size_border-offset, size_border, selected ? theme->col_selected_tab : theme->col_unselected_tab);
 			drawHLine(1+offset, 2+size_full*guiidx, size_border-offset, black);
 			drawVLine(0+offset, 3+size_full*guiidx, size_border - 1, black);
-			drawHLine(1+offset, 2+size_full*(guiidx+1), size_border-offset, black);
+			drawHLine(1+offset, 2+size_full*(guiidx+1), size_border-offset-1, black);
+			if (!selected) drawPixel(offset, 2+size_full*guiidx + size_border, theme->col_light_bg);
 			drawMonochromeIconOffset(2+offset, 4+size_full*guiidx, icon_size - offset, icon_size, 0, 0, icon_size, icon_size, icons.at(guiidx), theme->col_icon);
 		}
 	}

--- a/tobkit/source/theme.cpp
+++ b/tobkit/source/theme.cpp
@@ -107,8 +107,8 @@ ColorScheme::ColorScheme() {
 	col_tb_fg_on = col_light_ctrl;
 	col_piano_full_col1 = RGB15(31, 31, 31) | BIT(15);
 	col_piano_full_col2 = RGB15(25, 25, 25) | BIT(15);
-	col_piano_half_col1 = RGB15(8, 8, 8) | BIT(15);
-	col_piano_half_col2 = RGB15(0, 0, 0) | BIT(15);
+	col_piano_half_col1 = RGB15(0, 0, 0) | BIT(15);
+	col_piano_half_col2 = RGB15(8, 8, 8) | BIT(15);
 	col_piano_full_highlight_col1 = RGB15(24, 24, 30) | BIT(15);
 	col_piano_full_highlight_col2 = RGB15(20, 20, 26) | BIT(15);
 	col_piano_half_highlight_col1 = RGB15(20, 8, 8) | BIT(15);
@@ -168,14 +168,14 @@ bool Theme::stringToRGB15(char* str, u16* col)
 	int res = sscanf(str, "%02x%02x%02x", &r, &g, &b);
 	if (res < 3)
 		return false;
-	*col = (u16)(RGB15(r * 31 / 255, g * 31 / 255, b * 31 / 255) | BIT(15));
+	*col = (u16)(RGB15(r >> 3, g >> 3, b >> 3) | BIT(15));
 	return true;
 }
 
 // not needed as we are not writing themes currently
 void Theme::RGB15ToString(u16 col, char* str)
 {
-	sprintf(str, "%02x%02x%02x", (col & 0x1f) * 255 / 31, ((col >> 5) & 0x1f) * 255 / 31, (col >> 10 & 0x1f) * 255 / 31);
+	sprintf(str, "%02x%02x%02x", (col & 0x1f) << 3, ((col >> 5) & 0x1f) << 3, (col >> 10 & 0x1f) << 3);
 }
 
 
@@ -199,7 +199,7 @@ bool Theme::parseTheme(FILE* theme_, u16* theme_cols) {
 			debugprintf("theme parse error on line %d (key out of bounds, max %d)  \n", l + 1, NUM_COLORS - 1);
 			return false;
 		}
-		theme_cols[k] = RGB15(r * 31 / 255, g * 31 / 255, b * 31 / 255) | BIT(15);
+		theme_cols[k] = RGB15(r >> 3, g >> 3, b >> 3) | BIT(15);
 		theme_i++;
 	}
 

--- a/tobkit/source/togglebutton.cpp
+++ b/tobkit/source/togglebutton.cpp
@@ -50,6 +50,7 @@ void ToggleButton::pleaseDraw(void) {
 // Event calls
 void ToggleButton::penDown(u8 x, u8 y)
 {
+	if (!enabled) return;
 	penIsDown = true;
 	on = !on;
 	draw();
@@ -113,12 +114,12 @@ bool ToggleButton::getState(void)
 void ToggleButton::draw(void)
 {
 	if(!isExposed()) return;
-
-	u16 bg = theme->col_tb_bg;
+	u16 bg = enabled ? theme->col_tb_bg : theme->col_dark_ctrl_disabled;
 	drawFullBox(1, 1, width - 2, height - 2, bg);
 	drawBorder(theme->col_outline);
-
+	
 	u16 col;
+
 	if(penIsDown) {
 		if(on) {
 			col = bg;


### PR DESCRIPTION
see https://github.com/NitrousTracker/nitroustracker/pull/177 for more detail in review comments (mildly out of date)

also see https://github.com/NitrousTracker/libntxm/pull/19 (fixes weird behaviour regarding playing keys mapped to null samples)



change list copy pasted from previous pr:

* Switch the currently displayed/selected sample based on the multisample note just played
* Fix/implement the display and functioning of disabled state for many more widgets
* Draw a `col_signal` coloured outline around the piano when in mapping mode (the display of labels is ambiguous, as they also show when not mapping but lbsamples is shown)
* Do not hide the map samples button when the listbox for samples is not shown (see review comments for more info)
* Disable unusable controls within the sample and envelope editors if the current (sample/instrument) is null
* Fix a bug regarding drawing mapping labels when in mapping mode but after disabling the sample listbox
* Fix minor display bug with the tabbox where after deselecting a tab the rounding disappears
* Fix slightly inaccurate theme colour calc
* Fix `genPal` generating the default piano palette slightly differently to the original default theme (whoops my bad lol) 
* fix a slight inconsistency regarding the current sample when clicking on a new instrument which should reset it to 0, but only did so visually
