### PR TITLE
Extended instrument zapping

### DIFF
--- a/arm9/source/main.cpp
+++ b/arm9/source/main.cpp
@@ -1755,7 +1755,7 @@ void zapUnusedInstruments(void) {
 	song->zapUnusedInstruments(used_insts);
 
 	for (int i = 0; i < MAX_INSTRUMENTS; i++) {
-		if (!used_insts[i]) continue;
+		if (used_insts[i]) continue;
 
 		lbinstruments->set(i, "");
 		if (lbinstruments->getidx() == i) {


### PR DESCRIPTION
closes #179 #136 #54

This is what the dialogue looks like - it is an extra set of options on top of the zap -> instruments menu

<img width="508" height="385" alt="Screenshot_2025-11-23_22-21-57" src="https://github.com/user-attachments/assets/bcc9eddd-5014-4840-9eb4-e419ea9c220f" />

Also, requires https://github.com/NitrousTracker/libntxm/pull/21, because of a bug in Song.cpp that causes massive delays the more null instruments there are between two non-null ones 