### PR TITLE
Fix red border disappearing after recording from mic in edit mode

### DIFF
--- a/arm9/source/main.cpp
+++ b/arm9/source/main.cpp
@@ -2299,6 +2299,7 @@ void handleRecordSampleCancel(void)
 	CommandMicOff();
 
 	redrawSubScreen();
+	setRecordMode(state->recording);
 }
 
 // OMG FUCKING BEST FEATURE111

--- a/arm9/source/main.cpp
+++ b/arm9/source/main.cpp
@@ -2286,6 +2286,7 @@ void handleRecordSampleOK(void)
 	handleSampleChange(state->sample);
 	setHasUnsavedChanges(true);
 	redrawSubScreen();
+	setRecordMode(state->recording);
 }
 
 void handleRecordSampleCancel(void)


### PR DESCRIPTION
"`setRecordMode`" also draws the outline hence the seemingly redundant function call