### PR TITLE
Fix settings reading uninitialised values when config missing

### DIFF
--- a/arm9/source/settings.cpp
+++ b/arm9/source/settings.cpp
@@ -37,6 +37,8 @@ Settings::Settings(char *launch_path, bool use_fat)
 : handedness(RIGHT_HANDED),
 sample_preview(true),
 stereo_output(true),
+freq_47khz(false),
+lines_per_beat(8),
 fat(use_fat), changed(false)
 {
 	songpath[SETTINGS_FILENAME_LEN] = '\0';


### PR DESCRIPTION
This would cause "Lines Per Beat" to read a random number (usually 114) on first launch.

fixes #183 

(sorry for all the PR spam lol)