### PR TITLE
License header fix(?)

### DIFF
--- a/tobkit/include/tobkit/themeselectorbox.h
+++ b/tobkit/include/tobkit/themeselectorbox.h
@@ -1,5 +1,5 @@
 /*====================================================================
-Copyright 2006 Tobias Weyand
+Copyright 2025 R Ferreira
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tobkit/source/themeselectorbox.cpp
+++ b/tobkit/source/themeselectorbox.cpp
@@ -1,5 +1,5 @@
 /*====================================================================
-Copyright 2006 Tobias Weyand
+Copyright 2025 R Ferreira
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
I saw that in "platform.h"/"platform.cpp" the license header doesn't just say 2006 Tobias Weyand since they're new source files, and I had blindly copied that over with the theme classes

I honestly don't actually care about having the files attributed but I am only making this merge request since I assume I wasn't meant to put his name there which I didn't realise I did until a few hours ago lol 