### PR TITLE
font_pack.py: fix for fonts wider than 8px

### DIFF
--- a/tools/font_pack.py
+++ b/tools/font_pack.py
@@ -57,7 +57,7 @@ with open(sys.argv[2], "wb") as fp:
 					v = v | (1 << ix)
 					if (ix + 1) > width:
 						width = ix + 1
-			for ix in range(0, font_width, 8):
+			for ix in range(0, font_width, font_width):
 				fp.write(struct.pack("<B", (v >> ix) & 255))
 		if width == 0:
 			width = space_width


### PR DESCRIPTION
~~i was experimenting using tobkit in something else and was using a different font size, the text was initially rendering garbled and this change appears to fix it and of course doesn't break the existing font rendering, but perhaps i'm missing something~~