### PR TITLE
Show rename buttons as disabled if unusable; allow typewriter while song plays

### DIFF
--- a/arm9/source/main.cpp
+++ b/arm9/source/main.cpp
@@ -244,8 +244,8 @@ GUI *gui;
 // </Main Screen>
 
 // <Things that suddenly pop up>
-	Typewriter *tw;
-	MessageBox *mb;
+	Typewriter *tw = NULL;
+	MessageBox *mb = NULL;
 // </Things that suddenly pop up>
 
 u16 *b1n, *b1d;
@@ -631,7 +631,8 @@ void handleSampleChange(const u16 newsample)
 	buttonsmpnormalize->set_enabled(smp != NULL);
 	cbsnapto0xing->set_enabled(smp != NULL);
 	buttonsmpdraw->set_enabled(smp != NULL);
-
+	buttonrenameinst->set_enabled(inst != NULL);
+	buttonrenamesample->set_enabled(smp != NULL);
 	lbsamples->select(newsample);
 
 	if(smp == NULL)
@@ -1167,6 +1168,7 @@ void deleteTypewriter(void)
 	gui->unregisterOverlayWidget();
 	typewriter_active = false;
 	delete tw;
+	tw = NULL;
 	redrawSubScreen();
 }
 
@@ -1499,6 +1501,9 @@ void handlePotPosChangeFromSong(u16 newpotpos)
 
 	// Update other GUI Elements
 	updateGuiToNewPattern(song->getPotEntry(state->potpos));
+
+	if (tw)
+		tw->pleaseDraw();
 }
 
 #ifdef MIDI
@@ -2452,9 +2457,7 @@ void handleTypewriterSongnameOk(void)
 
 void showTypewriterForSongRename(void)
 {
-	if(!state->playing || state->pause) {
-		showTypewriter("song name", song->getName(), handleTypewriterSongnameOk, clearTypewriterText, deleteTypewriter);
-	}
+	showTypewriter("song name", song->getName(), handleTypewriterSongnameOk, clearTypewriterText, deleteTypewriter);
 }
 
 void handleTypewriterSampleOk(void)


### PR DESCRIPTION
Explicitly shows the "ren" buttons for instrument and sample as disabled if pressing them wouldn't do anything (in the case of a null sample or instrument).

Also, allows typewriters to appear whilst the song is playing, without having them be overlapped by `lbpot`, by redrawing the typewriter (if it exists) after every pattern change, i.e. after `lbpot` is redrawn, instead of just silently blocking the dialogue from appearing.