### PR TITLE
Skip updateKeyLabels if fx keyboard visible

### DIFF
--- a/arm9/source/main.cpp
+++ b/arm9/source/main.cpp
@@ -332,6 +332,8 @@ void drawSampleNumbers(void)
 
 void updateKeyLabels(void)
 {
+	if (fxkb->is_visible()) return;
+
 	kb->hideKeyLabels();
 	if(lbsamples->is_visible() == true)
 	{


### PR DESCRIPTION
Fixes a minor visual bug that happens when switching instrument in FX mode, which only happens if the key labels have previously been drawn