### PR TITLE
listbox.cpp: calcScrollThingy in ins and del

### DIFF
--- a/tobkit/source/listbox.cpp
+++ b/tobkit/source/listbox.cpp
@@ -189,6 +189,7 @@ void ListBox::del(void)
 		}
 		
 		if(activeelement >= scrollpos) {
+			calcScrollThingy();
 			draw();
 		}
 	}
@@ -198,7 +199,7 @@ void ListBox::del(void)
 void ListBox::ins(u16 idx, const char *name)
 {
 	elements.insert(elements.begin()+idx, name);
-	
+	calcScrollThingy();
 	draw();
 }
 


### PR DESCRIPTION
Fixes #210, an issue where pressing "ins" or "del" beside the pattern order table listbox wouldn't update the scrollbar.

`ins()` and `del()` seem to be designed towards user-caused insertions/deletions, and only the pattern order table listbox seems use these functions, so there seem to be no efficiency concerns regarding other listboxes that update many elements at once.